### PR TITLE
Update Guide and Poll events replication key 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.0.9
+  * Change Guide and Poll Events replication key
+
 ## 0.0.8
   * Add modified timestamp as max of ts and lastTs
 

--- a/README.md
+++ b/README.md
@@ -107,14 +107,14 @@ This tap:
 - Endpoint: [https://api/v1/aggregation](https://app.pendo.io/api/v1/aggregation)
 - Primary key fields:  `visitor_id`, `account_id`, `server`, `remote_ip`
 - Replication strategy: INCREMENTAL (query filtered)
-  - Bookmark: `day` or `hour`
+  - Bookmark: `browserTime`
 - Transformations: Camel to snake case.
 
 **[poll_events](https://developers.pendo.io/docs/?bash#get-an-account-by-id)**
 - Endpoint: [https://api/v1/aggregation](https://app.pendo.io/api/v1/aggregation)
 - Primary key fields:  `visitor_id`, `account_id`, `server`, `remote_ip`
 - Replication strategy: INCREMENTAL (query filtered)
-  - Bookmark: `day` or `hour`
+  - Bookmark: `browserTime`
 - Transformations: Camel to snake case.
 
 **[track_events](https://developers.pendo.io/docs/?bash#get-an-account-by-id)**

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-pendo",
-    version="0.0.8",
+    version="0.0.9",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="https://github.com/singer-io/tap-pendo",

--- a/tap_pendo/schemas/guide_events.json
+++ b/tap_pendo/schemas/guide_events.json
@@ -2,76 +2,67 @@
     "additional_properties": false,
     "type": "object",
     "properties": {
-      "app_id": {
-        "type": ["null", "number"]
-      },
-      "account_ids": {
-        "anyOf": [
-          {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          {
-            "type": "null"
-          }
-        ]
-      },
-      "day": {
-        "type": ["null", "string"],
-        "format": "date-time"
-      },
-      "hour": {
-        "type": ["null", "string"],
-        "format": "date-time"
-      },
-      "browser_time": {
-        "type": ["null", "string"],
-        "format": "date-time"
-      },
-      "country": {
-        "type": ["null", "string"]
-      },
-      "type": {
-        "type": ["null", "string"]
-      },
-      "guide_id": {
-        "type": ["null", "string"]
-      },
-      "latitude": {
-        "type": ["null", "number"]
-      },
-      "load_time": {
-        "type": ["null", "integer"]
-      },
-      "longitude": {
-        "type": ["null", "number"]
-      },
-      "poll_id": {
-        "type": ["null", "string"]
-      },
-      "region": {
-        "type": ["null", "string"]
-      },
-      "remote_ip": {
-        "type": ["null", "string"]
-      },
-      "server_name": {
-        "type": ["null", "string"]
-      },
-      "user_agent": {
-        "type": ["null", "string"]
-      },
-      "visitor_id": {
-        "type": ["null", "string"]
-      },
-      "account_id": {
-        "type": ["null", "string"]
-      },
-      "poll_response": {
-        "type": ["null", "string"]
-      }
+        "app_id": {
+            "type": ["null", "number"]
+        },
+        "account_ids": {
+            "anyOf": [
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
+        "browser_time": {
+            "type": ["null", "string"],
+            "format": "date-time"
+        },
+        "country": {
+            "type": ["null", "string"]
+        },
+        "type": {
+            "type": ["null", "string"]
+        },
+        "guide_id": {
+            "type": ["null", "string"]
+        },
+        "latitude": {
+            "type": ["null", "number"]
+        },
+        "load_time": {
+            "type": ["null", "integer"]
+        },
+        "longitude": {
+            "type": ["null", "number"]
+        },
+        "poll_id": {
+            "type": ["null", "string"]
+        },
+        "region": {
+            "type": ["null", "string"]
+        },
+        "remote_ip": {
+            "type": ["null", "string"]
+        },
+        "server_name": {
+            "type": ["null", "string"]
+        },
+        "user_agent": {
+            "type": ["null", "string"]
+        },
+        "visitor_id": {
+            "type": ["null", "string"]
+        },
+        "account_id": {
+            "type": ["null", "string"]
+        },
+        "poll_response": {
+            "type": ["null", "string"]
+        }
     }
-  }
-  
+}

--- a/tap_pendo/schemas/poll_events.json
+++ b/tap_pendo/schemas/poll_events.json
@@ -24,14 +24,6 @@
       "guide_id": {
         "type": ["null", "string"]
       },
-      "day": {
-        "type": ["null", "string"],
-        "format": "date-time"
-      },
-      "hour": {
-        "type": ["null", "string"],
-        "format": "date-time"
-      },
       "browser_time": {
         "type": ["null", "string"],
         "format": "date-time"

--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -643,6 +643,7 @@ class PollEvents(Stream):
         self.replication_key = 'browser_time'
 
     def get_body(self, period, first):
+        sort = humps.camelize(self.replication_key)
         return {
             "response": {
                 "mimeType": "application/json"
@@ -657,10 +658,11 @@ class PollEvents(Stream):
                             "last": "now()"
                         }
                     }
-                }, {
-                    "sort": [self.replication_key]
-                }]
-            }
+                }, 
+                {
+                    "sort": [sort]
+                }
+            ]}
         }
 
     def sync(self, state, start_date=None, key_id=None):
@@ -721,6 +723,7 @@ class GuideEvents(EventsBase):
         self.replication_key = 'browser_time'
 
     def get_body(self, key_id, period, first):
+        sort = humps.camelize(self.replication_key)
         return {
             "response": {
                 "mimeType": "application/json"
@@ -737,8 +740,9 @@ class GuideEvents(EventsBase):
                             "last": "now()"
                         }
                     }
-                }, {
-                    "sort": [self.replication_key]
+                }, 
+                {
+                    "sort": [sort]
                 }]
             }
         }

--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -351,10 +351,11 @@ class Stream():
                                        'inclusion', 'available')
 
         # For period stream adjust schema for time period
-        if hasattr(self, 'period') and self.period == 'hourRange':
-            mdata.pop(('properties', 'day'))
-        elif hasattr(self, 'period') and self.period == 'dayRange':
-            mdata.pop(('properties', 'hour'))
+        if self.replication_key == 'day' or self.replication_key == 'hour':
+            if hasattr(self, 'period') and self.period == 'hourRange':
+                mdata.pop(('properties', 'day'))
+            elif hasattr(self, 'period') and self.period == 'dayRange':
+                mdata.pop(('properties', 'hour'))
 
         return metadata.to_list(mdata)
 
@@ -639,7 +640,7 @@ class PollEvents(Stream):
         super().__init__(config=config)
         self.config = config
         self.period = config.get('period')
-        self.replication_key = "day" if self.period == 'dayRange' else "hour"
+        self.replication_key = 'browser_time'
 
     def get_body(self, period, first):
         return {
@@ -712,6 +713,12 @@ class GuideEvents(EventsBase):
     replication_method = "INCREMENTAL"
     name = "guide_events"
     key_properties = ['visitor_id', 'account_id', 'server_name', 'remote_ip']
+
+    def __init__(self, config):
+        super().__init__(config=config)
+        self.config = config
+        self.period = config.get('period')
+        self.replication_key = 'browser_time'
 
     def get_body(self, key_id, period, first):
         return {

--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -658,11 +658,10 @@ class PollEvents(Stream):
                             "last": "now()"
                         }
                     }
-                }, 
-                {
+                }, {
                     "sort": [sort]
-                }
-            ]}
+                }]
+            }
         }
 
     def sync(self, state, start_date=None, key_id=None):
@@ -729,21 +728,23 @@ class GuideEvents(EventsBase):
                 "mimeType": "application/json"
             },
             "request": {
-                "pipeline": [{
-                    "source": {
-                        "guideEvents": {
-                            "guideId": key_id
-                        },
-                        "timeSeries": {
-                            "period": period,
-                            "first": first,
-                            "last": "now()"
+                "pipeline": [
+                    {
+                        "source": {
+                            "guideEvents": {
+                                "guideId": key_id
+                            },
+                            "timeSeries": {
+                                "period": period,
+                                "first": first,
+                                "last": "now()"
+                                }
                         }
+                    },
+                    {
+                        "sort": [sort]
                     }
-                }, 
-                {
-                    "sort": [sort]
-                }]
+                ]
             }
         }
 


### PR DESCRIPTION
# Description of change
Not all time series streams are aggregated on a time period; namely, guide and poll events. In these cases the replication key should be `browserTime`, see https://developers.pendo.io/docs/?bash#events-ungrouped

# Manual QA steps
 Ran:

1. Discover
```
INFO Starting discover
INFO Discovering custom fields for Accounts
INFO GET https://app.pendo.io/api/v1/metadata/schema/account None
INFO Discovering custom fields for Visitors
INFO GET https://app.pendo.io/api/v1/metadata/schema/visitor None
INFO Finished discover
INFO Catalog configuration starting...
? Select Streams  done (15 selections)
? Select fields from stream: `accounts`  done (2 selections)
? Select fields from stream: `features`  done (13 selections)
? Select fields from stream: `guides`  done (16 selections)
? Select fields from stream: `pages`  done (12 selections)
? Select fields from stream: `visitor_history`  done (12 selections)
? Select fields from stream: `visitors`  done (3 selections)
? Select fields from stream: `feature_events`  done (6 selections)
? Select fields from stream: `events`  done (7 selections)
? Select fields from stream: `page_events`  done (6 selections)
? Select fields from stream: `guide_events`  done (12 selections)
? Select fields from stream: `poll_events`  done (11 selections)
? Select fields from stream: `track_types`  done (13 selections)
? Select fields from stream: `track_events`  done (6 selections)
? Select fields from stream: `metadata_accounts`  done (2 selections)
? Select fields from stream: `metadata_visitors`  done (4 selections)
INFO Catalog configuration saved.
```
2. Singer Check Tap
Result:
```
Checking stdin for valid Singer-formatted data
The output is valid.
It contained 56222 messages for 14 streams.

     17 schema messages
  55859 record messages
    346 state messages

Details by stream:
+-------------------+---------+---------+
| stream            | records | schemas |
+-------------------+---------+---------+
| accounts          | 47      | 1       |
| features          | 32      | 1       |
| feature_events    | 2885    | 2       |
| guides            | 2       | 1       |
| guide_events      | 115     | 2       |
| pages             | 34      | 1       |
| page_events       | 14943   | 2       |
| visitors          | 11253   | 1       |
| events            | 26546   | 1       |
| poll_events       | 0       | 1       |
| track_types       | 0       | 1       |
| track_events      | 0       | 1       |
| metadata_accounts | 1       | 1       |
| metadata_visitors | 1       | 1       |
+-------------------+---------+---------+

3. Target Stitch
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
