### PR TITLE
Allow for None return

### DIFF
--- a/tap_pendo/discover.py
+++ b/tap_pendo/discover.py
@@ -97,11 +97,11 @@ def discover_streams(config):
 
     LOGGER.info("Discovering custom fields for Accounts")
     custom_account_fields = STREAMS['metadata_accounts'](
-        config).get_fields().get('custom')
+        config).get_fields().get('custom') or {}
 
     LOGGER.info("Discovering custom fields for Visitors")
     custom_visitor_fields = STREAMS['metadata_visitors'](
-        config).get_fields().get('custom')
+        config).get_fields().get('custom') or {}
 
     for s in STREAMS.values():
 


### PR DESCRIPTION
# Description of change
I was receiving an error of 
"tap - CRITICAL 'NoneType' object has no attribute 'items'" probably because I had no Accounts or Visitors stream.

# Manual QA steps
 I ran the tap on my local virtual env and selected guides (one of the streams we have)
<img width="1027" alt="Screen Shot 2021-01-13 at 10 30 31 PM" src="https://user-images.githubusercontent.com/46604073/104541559-d2f8d680-55ef-11eb-8216-faa51986a795.png">
<img width="1008" alt="Screen Shot 2021-01-13 at 10 34 44 PM" src="https://user-images.githubusercontent.com/46604073/104541566-d724f400-55ef-11eb-8a38-1a92a1456804.png">

 
# Risks
 - None that I can think of...
 
# Rollback steps
 - revert this branch
