### PR TITLE
Add visitor identified config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.0.9
+  * Add optional sync for anonymous Visitors
+
 ## 0.0.8
   * Add modified timestamp as max of ts and lastTs
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-#  tap-pendo
+# tap-pendo
+
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Python 3.7](https://upload.wikimedia.org/wikipedia/commons/f/fc/Blue_Python_3.7_Shield_Badge.svg)](https://www.python.org/downloads/release/python-370/)
 
@@ -13,28 +14,29 @@ This tap:
 
 - Pulls raw data from the [Pendo API](https://developers.pendo.io/docs/?bash#overview).
 - Extracts the following resources:
-    * Accounts
-    * Features
-    * Guides
-    * Pages
-    * Visitor History
-      * Syncs for this endpoint may be very long running.
-    * Visitors
-    * Track Types
-    * Feature Events
-    * Events
-    * Page Events
-    * Guide Events
-    * Poll Events
-    * Track Events
-    * Metadata Accounts
-    * Metadata Visitors
+  - Accounts
+  - Features
+  - Guides
+  - Pages
+  - Visitors
+  - Visitor History
+    - Syncs for this endpoint may be very long running if extracting anonymous visitors, see Visitors config `visitors_identified`.
+  - Track Types
+  - Feature Events
+  - Events
+  - Page Events
+  - Guide Events
+  - Poll Events
+  - Track Events
+  - Metadata Accounts
+  - Metadata Visitors
 - Outputs the schema for each resource
 - Incrementally pulls data based on the input state
 
 ## Streams
 
 **[accounts](https://developers.pendo.io/docs/?bash#entities)**
+
 - Endpoint: [https://api/v1/aggregation](https://app.pendo.io/api/v1/aggregation)
 - Primary key fields: `account_id`
 - Replication strategy: INCREMENTAL (query filtered)
@@ -45,6 +47,7 @@ This tap:
   - `metadata` objects denested(`metadata_agent`, `metadata_audo`, `metadata_custom`, etc)
 
 **[features](https://developers.pendo.io/docs/?bash#entities)**
+
 - Endpoint: [https://api/v1/aggregation](https://app.pendo.io/api/v1/feature)
 - Primary key fields: `id`
 - Replication strategy: INCREMENTAL (query filtered)
@@ -52,6 +55,7 @@ This tap:
 - Transformations: Camel to snake case.
 
 **[guides](https://developers.pendo.io/docs/?bash#entities)**
+
 - Endpoint: [https://api/v1/aggregation](https://app.pendo.io/api/v1/aggregation)
 - Primary key fields: `id`
 - Replication strategy: INCREMENTAL (query filtered)
@@ -59,6 +63,7 @@ This tap:
 - Transformations: Camel to snake case.
 
 **[track types](https://developers.pendo.io/docs/?bash#entities)**
+
 - Endpoint: [https://api/v1/aggregation](https://app.pendo.io/api/v1/aggregation)
 - Primary key fields: `id`
 - Replication strategy: INCREMENTAL (query filtered)
@@ -66,23 +71,29 @@ This tap:
 - Transformations: Camel to snake case.
 
 **[visitors](https://developers.pendo.io/docs/?bash#entities)**
+
 - Endpoint: [https://api/v1/aggregation](https://app.pendo.io/api/v1/aggregation)
 - Primary key fields: `visitor_id`
 - Replication strategy: INCREMENTAL (query filtered)
   - Bookmark: `lastupdated`
+- Config option: `visitors_identified`: `true`/`false`
+  - Default: `true` to eliminate anonymous visitors
+  - https://developers.pendo.io/docs/?bash#source-specification
 - Transformations
   - Camel to snake case.
   - `metadata.auto.lastupdated` denested to root as `lastupdated`
   - `metadata` objects denested(`metadata_agent`, `metadata_audo`, `metadata_custom`, etc)
 
 **[visitor_history](https://developers.pendo.io/docs/?bash#get-an-account-by-id)**
+
 - Endpoint: [https://api/v1/aggregation](https://app.pendo.io/api/v1/aggregation)
 - Primary key fields: `visitor_id`
 - Replication strategy: INCREMENTAL (query filtered)
   - Bookmark: `modified_ts` (Max from `ts` or `lastTs`)
-- Transformations: Camel to snake case. 
+- Transformations: Camel to snake case.
 
 **[feature_events](https://developers.pendo.io/docs/?bash#get-an-account-by-id)**
+
 - Endpoint: [https://api/v1/aggregation](https://app.pendo.io/api/v1/aggregation)
 - Primary key fields: `visitor_id`, `account_id`, `server`, `remote_ip`
 - Replication strategy: INCREMENTAL (query filtered)
@@ -90,41 +101,47 @@ This tap:
 - Transformations: Camel to snake case.
 
 **[events](https://developers.pendo.io/docs/?bash#get-an-account-by-id)**
+
 - Endpoint: [https://api/v1/aggregation](https://app.pendo.io/api/v1/aggregation)
-- Primary key fields:  `visitor_id`, `account_id`, `server`, `remote_ip`
+- Primary key fields: `visitor_id`, `account_id`, `server`, `remote_ip`
 - Replication strategy: INCREMENTAL (query filtered)
   - Bookmark: `day` or `hour`
 - Transformations: Camel to snake case.
 
 **[page_events](https://developers.pendo.io/docs/?bash#get-an-account-by-id)**
+
 - Endpoint: [https://api/v1/aggregation](https://app.pendo.io/api/v1/aggregation)
-- Primary key fields:  `visitor_id`, `account_id`, `server`, `remote_ip`
+- Primary key fields: `visitor_id`, `account_id`, `server`, `remote_ip`
 - Replication strategy: INCREMENTAL (query filtered)
   - Bookmark: `day` or `hour`
 - Transformations: Camel to snake case.
 
 **[guide_events](https://developers.pendo.io/docs/?bash#get-an-account-by-id)**
+
 - Endpoint: [https://api/v1/aggregation](https://app.pendo.io/api/v1/aggregation)
-- Primary key fields:  `visitor_id`, `account_id`, `server`, `remote_ip`
+- Primary key fields: `visitor_id`, `account_id`, `server`, `remote_ip`
 - Replication strategy: INCREMENTAL (query filtered)
   - Bookmark: `day` or `hour`
 - Transformations: Camel to snake case.
 
 **[poll_events](https://developers.pendo.io/docs/?bash#get-an-account-by-id)**
+
 - Endpoint: [https://api/v1/aggregation](https://app.pendo.io/api/v1/aggregation)
-- Primary key fields:  `visitor_id`, `account_id`, `server`, `remote_ip`
+- Primary key fields: `visitor_id`, `account_id`, `server`, `remote_ip`
 - Replication strategy: INCREMENTAL (query filtered)
   - Bookmark: `day` or `hour`
 - Transformations: Camel to snake case.
 
 **[track_events](https://developers.pendo.io/docs/?bash#get-an-account-by-id)**
+
 - Endpoint: [https://api/v1/aggregation](https://app.pendo.io/api/v1/aggregation)
-- Primary key fields:  `visitor_id`, `account_id`, `server`, `remote_ip`
+- Primary key fields: `visitor_id`, `account_id`, `server`, `remote_ip`
 - Replication strategy: INCREMENTAL (query filtered)
   - Bookmark: `day` or `hour`
 - Transformations: Camel to snake case.
 
 **[guides](https://developers.pendo.io/docs/?bash#entities)**
+
 - Endpoint: [https://api/v1/aggregation](https://app.pendo.io/api/v1/aggregation)
 - Primary key fields: `id`
 - Replication strategy: INCREMENTAL (query filtered)
@@ -132,11 +149,13 @@ This tap:
 - Transformations: Camel to snake case.
 
 **[metadata accounts](https://developers.pendo.io/docs/?bash#automatically-generated-metadata)**
+
 - Endpoint: [https://api/v1/metadata/schema/account](https://app.pendo.io/api/v1/metadata/schema/account)
 - Replication strategy: FULL_TABLE
 - Transformations: Camel to snake case.
 
 **[metadata visitors](https://developers.pendo.io/docs/?bash#automatically-generated-metadata)**
+
 - Endpoint: [https://api/v1/metadata/schema/account](https://app.pendo.io/api/v1/metadata/schema/visitor)
 - Replication strategy: FULL_TABLE
 - Transformations: Camel to snake case.
@@ -167,6 +186,7 @@ Authentication is managed by integration keys. An integration key may be created
 ```
 
 Interrupted syncs for Event type stream are resumed via a bookmark placed during processing, `last_processed`. The value of the parent GUID will be
+
 ```json
 {
   "bookmarks": {
@@ -189,133 +209,151 @@ Interrupted syncs for Event type stream are resumed via a bookmark placed during
 }
 ```
 
-
 ## Quick Start
 
 1. Install
 
-    Clone this repository, and then install using setup.py. We recommend using a virtualenv:
+   Clone this repository, and then install using setup.py. We recommend using a virtualenv:
 
-    ```bash
-    > virtualenv -p python3 venv
-    > source venv/bin/activate
-    > python setup.py install
-    OR
-    > cd .../tap-pendo
-    > pip install .
-    ```
+   ```bash
+   > virtualenv -p python3 venv
+   > source venv/bin/activate
+   > python setup.py install
+   OR
+   > cd .../tap-pendo
+   > pip install .
+   ```
+
 2. Dependent libraries. The following dependent libraries were installed.
-    ```bash
-    > pip install singer-python
-    > pip install jsonlines
-    > pip install singer-tools
-    > pip install target-stitch
-    > pip install target-json
 
-    ```
-    - [singer-tools](https://github.com/singer-io/singer-tools)
-    - [target-stitch](https://github.com/singer-io/target-stitch)
-    - [jsonlines](https://jsonlines.readthedocs.io/en/latest/)
+   ```bash
+   > pip install singer-python
+   > pip install jsonlines
+   > pip install singer-tools
+   > pip install target-stitch
+   > pip install target-json
 
-3. Create your tap's `config.json` file.  The tap config file for this tap should include these entries:
+   ```
+
+   - [singer-tools](https://github.com/singer-io/singer-tools)
+   - [target-stitch](https://github.com/singer-io/target-stitch)
+   - [jsonlines](https://jsonlines.readthedocs.io/en/latest/)
+
+3. Create your tap's `config.json` file. The tap config file for this tap should include these entries:
+
    - `start_date` - the default value to use if no bookmark exists for an endpoint (rfc3339 date string)
    - `x_pendo_integration_key` (string, `ABCdef123`): an integration key from Pendo.
    - `period` (string, `ABCdef123`): `dayRange` or `hourRange`
    - `lookback_window` (integer): 10 (For event objects. Default: 0)
 
-    ```json
-    {
-      "x_pendo_integration_key": "YOUR_INTEGRATION_KEY",
-      "start_date": "2020-09-18T00:00:00Z",
-      "period": "dayRange",
-      "lookback_window": 10
-    }
-    ```
+   ```json
+   {
+     "x_pendo_integration_key": "YOUR_INTEGRATION_KEY",
+     "start_date": "2020-09-18T00:00:00Z",
+     "period": "dayRange",
+     "lookback_window": 10,
+     "visitors_identified: "false"
+   }
+   ```
 
 4. Run the Tap in Discovery Mode
-    This creates a catalog.json for selecting objects/fields to integrate:
-    ```bash
-    tap-pendo --config config.json --discover > catalog.json
-    ```
+   This creates a catalog.json for selecting objects/fields to integrate:
+
+   ```bash
+   tap-pendo --config config.json --discover > catalog.json
+   ```
+
    See the Singer docs on discovery mode
    [here](https://github.com/singer-io/getting-started/blob/master/docs/DISCOVERY_MODE.md#discovery-mode).
 
 5. Run the Tap in Sync Mode (with catalog) and [write out to state file](https://github.com/singer-io/getting-started/blob/master/docs/RUNNING_AND_DEVELOPING.md#running-a-singer-tap-with-a-singer-target)
 
-    For Sync mode:
-    ```bash
-    > tap-pendo --config tap_config.json --catalog catalog.json > state.json
-    > tail -1 state.json > state.json.tmp && mv state.json.tmp state.json
-    ```
-    To load to json files to verify outputs:
-    ```bash
-    > tap-pendo --config tap_config.json --catalog catalog.json | target-json > state.json
-    > tail -1 state.json > state.json.tmp && mv state.json.tmp state.json
-    ```
-    To pseudo-load to [Stitch Import API](https://github.com/singer-io/target-stitch) with dry run:
-    ```bash
-    > tap-pendo --config tap_config.json --catalog catalog.json | target-stitch --config target_config.json --dry-run > state.json
-    > tail -1 state.json > state.json.tmp && mv state.json.tmp state.json
-    ```
+   For Sync mode:
+
+   ```bash
+   > tap-pendo --config tap_config.json --catalog catalog.json > state.json
+   > tail -1 state.json > state.json.tmp && mv state.json.tmp state.json
+   ```
+
+   To load to json files to verify outputs:
+
+   ```bash
+   > tap-pendo --config tap_config.json --catalog catalog.json | target-json > state.json
+   > tail -1 state.json > state.json.tmp && mv state.json.tmp state.json
+   ```
+
+   To pseudo-load to [Stitch Import API](https://github.com/singer-io/target-stitch) with dry run:
+
+   ```bash
+   > tap-pendo --config tap_config.json --catalog catalog.json | target-stitch --config target_config.json --dry-run > state.json
+   > tail -1 state.json > state.json.tmp && mv state.json.tmp state.json
+   ```
 
 6. Test the Tap
 
-    While developing the pendo tap, the following utilities were run in accordance with Singer.io best practices:
-    Pylint to improve [code quality](https://github.com/singer-io/getting-started/blob/master/docs/BEST_PRACTICES.md#code-quality):
-    ```bash
-    > pylint tap_pendo -d missing-docstring -d logging-format-interpolation -d too-many-locals -d too-many-arguments
-    ```
-    Pylint test resulted in the following score:
-    ```bash
-    Your code has been rated at 9.67/10
-    ```
+   While developing the pendo tap, the following utilities were run in accordance with Singer.io best practices:
+   Pylint to improve [code quality](https://github.com/singer-io/getting-started/blob/master/docs/BEST_PRACTICES.md#code-quality):
 
-    To [check the tap](https://github.com/singer-io/singer-tools#singer-check-tap) and verify working:
-    ```bash
-    > tap-pendo --config tap_config.json --catalog catalog.json | singer-check-tap > state.json
-    > tail -1 state.json > state.json.tmp && mv state.json.tmp state.json
-    ```
-    Check tap resulted in the following:
-    ```bash
-    Checking stdin for valid Singer-formatted data
-    The output is valid.
-    It contained 3734 messages for 11 streams.
+   ```bash
+   > pylint tap_pendo -d missing-docstring -d logging-format-interpolation -d too-many-locals -d too-many-arguments
+   ```
 
-        13 schema messages
-      3702 record messages
-        19 state messages
+   Pylint test resulted in the following score:
 
-    Details by stream:
-    +----------------+---------+---------+
-    | stream         | records | schemas |
-    +----------------+---------+---------+
-    | accounts       | 1       | 1       |
-    | features       | 29      | 1       |
-    | feature_events | 158     | 2       |
-    | guides         | 0       | 1       |
-    | pages          | 34      | 1       |
-    | page_events    | 830     | 2       |
-    | reports        | 2       | 1       |
-    | visitors       | 1902    | 1       |
-    | events         | 746     | 1       |
-    | guide_events   | 0       | 1       |
-    | poll_events    | 0       | 1       |
-    +----------------+---------+---------+
-    ```
+   ```bash
+   Your code has been rated at 9.67/10
+   ```
 
-    #### Unit Tests
+   To [check the tap](https://github.com/singer-io/singer-tools#singer-check-tap) and verify working:
 
-    Unit tests may be run with the following.
+   ```bash
+   > tap-pendo --config tap_config.json --catalog catalog.json | singer-check-tap > state.json
+   > tail -1 state.json > state.json.tmp && mv state.json.tmp state.json
+   ```
 
-    ```
-    python -m pytest --verbose
-    ```
+   Check tap resulted in the following:
 
-    Note, you may need to install test dependencies.
+   ```bash
+   Checking stdin for valid Singer-formatted data
+   The output is valid.
+   It contained 3734 messages for 11 streams.
 
-    ```
-    pip install -e .'[dev]'
-    ```
+       13 schema messages
+     3702 record messages
+       19 state messages
+
+   Details by stream:
+   +----------------+---------+---------+
+   | stream         | records | schemas |
+   +----------------+---------+---------+
+   | accounts       | 1       | 1       |
+   | features       | 29      | 1       |
+   | feature_events | 158     | 2       |
+   | guides         | 0       | 1       |
+   | pages          | 34      | 1       |
+   | page_events    | 830     | 2       |
+   | reports        | 2       | 1       |
+   | visitors       | 1902    | 1       |
+   | events         | 746     | 1       |
+   | guide_events   | 0       | 1       |
+   | poll_events    | 0       | 1       |
+   +----------------+---------+---------+
+   ```
+
+   #### Unit Tests
+
+   Unit tests may be run with the following.
+
+   ```
+   python -m pytest --verbose
+   ```
+
+   Note, you may need to install test dependencies.
+
+   ```
+   pip install -e .'[dev]'
+   ```
+
 ---
 
 Copyright &copy; 2020 Stitch

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-pendo",
-    version="0.0.8",
+    version="0.0.9",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="https://github.com/singer-io/tap-pendo",

--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -913,19 +913,22 @@ class Visitors(Stream):
         return "/api/v1/aggregation"
 
     def get_body(self):
+        visitors_identified = True if self.config.get(
+            'visitors_identified', 'true').lower() == 'true' else False
         return {
             "response": {
                 "mimeType": "application/json"
             },
             "request": {
-                "name": "all-visitors",
-                "pipeline": [
-                    {
-                        "source": {
-                            "visitors": None
+                "name":
+                "all-visitors",
+                "pipeline": [{
+                    "source": {
+                        "visitors": {
+                            "identified": visitors_identified
                         }
                     }
-                ],
+                }],
                 "requestId": "all-visitors",
                 "sort": [
                     "visitorId"


### PR DESCRIPTION
# Description of change
Add optional config parameter to sync of anonymous Visitors. Default to identified visitors only.

# Manual QA steps

## Discover

```
~/.virtualenvs/tap-pendo-release/bin/tap-pendo --config tap_config.json --discover | ~/.virtualenvs/singer-discover/bin/singer-discover --output catalog.json
INFO Starting discover
INFO Discovering custom fields for Accounts
INFO GET https://app.pendo.io/api/v1/metadata/schema/account None
INFO Discovering custom fields for Visitors
INFO GET https://app.pendo.io/api/v1/metadata/schema/visitor None
INFO Finished discover
INFO Catalog configuration starting...
? Select Streams  done (15 selections)
? Select fields from stream: `accounts`  done (2 selections)
? Select fields from stream: `features`  done (13 selections)
? Select fields from stream: `guides`  done (16 selections)
? Select fields from stream: `pages`  done (12 selections)
? Select fields from stream: `visitor_history`  done (12 selections)
? Select fields from stream: `visitors`  done (3 selections)
? Select fields from stream: `feature_events`  done (6 selections)
? Select fields from stream: `events`  done (7 selections)
? Select fields from stream: `page_events`  done (6 selections)
? Select fields from stream: `guide_events`  done (13 selections)
? Select fields from stream: `poll_events`  done (12 selections)
? Select fields from stream: `track_types`  done (13 selections)
? Select fields from stream: `track_events`  done (6 selections)
? Select fields from stream: `metadata_accounts`  done (2 selections)
? Select fields from stream: `metadata_visitors`  done (4 selections)
INFO Catalog configuration saved.
```

## Check Tap

```
The output is valid.
It contained 2930 messages for 15 streams.

     19 schema messages
   2437 record messages
    474 state messages

Details by stream:
+-------------------+---------+---------+
| stream            | records | schemas |
+-------------------+---------+---------+
| accounts          | 47      | 1       |
| features          | 32      | 1       |
| feature_events    | 52      | 2       |
| guides            | 2       | 1       |
| guide_events      | 1104    | 2       |
| pages             | 34      | 1       |
| page_events       | 89      | 2       |
| visitor_history   | 0       | 2       |
| visitors          | 42      | 1       |
| events            | 1033    | 1       |
| poll_events       | 0       | 1       |
| track_types       | 0       | 1       |
| track_events      | 0       | 1       |
| metadata_accounts | 1       | 1       |
| metadata_visitors | 1       | 1       |
+-------------------+---------+---------+
Execution time: 0h:28m:33s sec   
```
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
