### PR TITLE
Fix/custom fields discovery

### DIFF
--- a/tap_pendo/discover.py
+++ b/tap_pendo/discover.py
@@ -49,12 +49,15 @@ def get_custom_fields(instance):
     return instance.get_fields().get('custom')
 
 
-def get_schema_propery_type(schema_type):
+def get_schema_property_type(schema_type):
     if schema_type == 'string':
         return {"type": ["null", "string"]}
     elif schema_type == 'time':
         return {"type": ["null", "string"], "format": "date-time"}
-    return None
+    elif schema_type == 'boolean':
+        return {"type": ["null", "boolean"]}
+
+    raise Exception("No case matching JSON schema for property type: {}".format(schema_type))
 
 
 def build_metadata_metadata(mdata, schema, custom_fields):

--- a/tap_pendo/discover.py
+++ b/tap_pendo/discover.py
@@ -68,7 +68,6 @@ def build_metadata_metadata(mdata, schema, custom_fields):
     for key, _ in custom_fields.items():
         schema['properties']['custom']['properties'] = {}
         schema['properties']['custom']['properties'][key] = {}
-        schema['properties']['custom']['properties'][key]['properties'] = {}
         schema['properties']['custom']['properties'][key]['type'] = [
             "null", "object"
         ]
@@ -89,7 +88,8 @@ def build_account_visitor_metadata(mdata, schema, custom_fields):
     for key, value in custom_fields.items():
         schema['properties']['metadata_custom']['type'] = ["null", "object"]
         schema['properties']['metadata_custom']['properties'] = {
-            key: get_schema_propery_type(value.get('type'))
+            **schema['properties']['metadata_custom'].get('properties', {}),
+            key: get_schema_property_type(value.get('type'))
         }
         mdata = metadata.write(mdata, ("properties", 'metadata_custom'),
                                'inclusion', 'available')


### PR DESCRIPTION
# Description of change
There's quite a subtle issue with discovery and custom fields for `visitors` and `accounts`. In the case that a custom field type is not matched with an associated JSON schema type, an invalid schema type of `null` would be generated.

If there are more than one custom fields defined for these streams, the last one received would be overwritten due to the loop overwriting the `properties` schema. Thus, with the inclusion of `additional_properties: false`, only one field (of random order) will be able to come through on records.

# Manual QA steps
 - Ran through this in a debugger and manually inspected each response to be sure it's all being captured now.
 
# Risks
 - Low, these are fairly obvious issues once you see them, and are rather clearly wrong in the tap's current state.
 
# Rollback steps
 - revert this branch, bump patch version, re-release
