### PR TITLE
Stream JSON response for visitors and events using ijson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.0.12
+  * Stream `visitors` and `events` aggregation responses via ijson [#28](https://github.com/singer-io/tap-pendo/pull/28)
+
 ## 0.0.11
   * Fix for discovering all custom fields in `visitors` and `accounts` [#27](https://github.com/singer-io/tap-pendo/pull/27)
   * Add boolean type handling to custom field discovery [#27](https://github.com/singer-io/tap-pendo/pull/27)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ setup(
         'singer-python==5.2.1',
         "requests",
         'pyhumps==1.3.1',
-        'backoff==1.3.2'
+        'backoff==1.3.2',
+        'ijson==3.1.4',
     ],
     extras_require={
         'dev': [

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-pendo",
-    version="0.0.11",
+    version="0.0.12",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="https://github.com/singer-io/tap-pendo",


### PR DESCRIPTION
# Description of change
The [aggregation API](https://developers.pendo.io/docs/?bash#aggregation) returns results as a JSON blob with all rows present under a `results` key.

This is fine for most streams that use this API, however, `visitors` and `events` can have a huge amount of data, causing upwards of 5gb of memory being required to load the entire set.

This PR takes advantage of [ijson](https://github.com/ICRAR/ijson) used in other Singer taps to stream the contents of the `results` key in the response.

# Manual QA steps
 - Ran through a large dataset of events and visitors and the tap was able to extract them successfully.
 - Ran through the rest of the unmodified streams to confirm they also do not throw
 
# Risks
 - Low, my expertise lies more in the realm of Singer and streaming JSON rather than this specific tap or Pendo itself, but I feel I have covered my bases in my manual testing scenarios above.
 
# Rollback steps
 - revert this branch, bump patch version, re-release
