### PR TITLE
Fix/visitors sub stream slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.0.13
+  * Fix issue with substreams of visitors due to new pattern using a generator rather than a list [#29](https://github.com/singer-io/tap-pendo/pull/28)
+
 ## 0.0.12
   * Stream `visitors` and `events` aggregation responses via ijson [#28](https://github.com/singer-io/tap-pendo/pull/28)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-pendo",
-    version="0.0.12",
+    version="0.0.13",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="https://github.com/singer-io/tap-pendo",

--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -393,7 +393,12 @@ class Stream():
                 if e.get(parent.key_properties[0]) == last_processed:
                     LOGGER.info("Resuming %s sync with %s", sub_stream.name, e.get(parent.key_properties[0]))
                     if isinstance(parent_response, list):
-                        parent_response = parent_response[i:]
+                        try:
+                            starting_index = parent_response.index(e)
+                        except ValueError as err:
+                            LOGGER.warn("Could not find %s, starting over")
+                            starting_index = 0
+                        parent_response = parent_response[starting_index:]
                     else:
                         parent_response = itertools.chain([e], parent_response)
                     break

--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -388,7 +388,6 @@ class Stream():
 
         # Slice response for >= last processed
         if last_processed:
-            ## TODO: What happens when there's a list that comes in here????
             i = 0
             for response in parent_response:
                 if response.get(parent.key_properties[0]) == last_processed:

--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -389,19 +389,16 @@ class Stream():
         # Slice response for >= last processed
         if last_processed:
             ## TODO: What happens when there's a list that comes in here????
-            for e in parent_response:
-                if e.get(parent.key_properties[0]) == last_processed:
-                    LOGGER.info("Resuming %s sync with %s", sub_stream.name, e.get(parent.key_properties[0]))
+            i = 0
+            for response in parent_response:
+                if response.get(parent.key_properties[0]) == last_processed:
+                    LOGGER.info("Resuming %s sync with %s", sub_stream.name, response.get(parent.key_properties[0]))
                     if isinstance(parent_response, list):
-                        try:
-                            starting_index = parent_response.index(e)
-                        except ValueError as err:
-                            LOGGER.warn("Could not find %s, starting over")
-                            starting_index = 0
-                        parent_response = parent_response[starting_index:]
+                        parent_response = parent_response[i:]
                     else:
-                        parent_response = itertools.chain([e], parent_response)
+                        parent_response = itertools.chain([response], parent_response)
                     break
+                i += 1
 
         for record in parent_response:
             try:

--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -392,7 +392,7 @@ class Stream():
             for i, e in enumerate(parent_response):
                 if e.get(parent.key_properties[0]) == last_processed:
                     LOGGER.info("Resuming %s sync with %s", sub_stream.name, e.get(parent.key_properties[0]))
-                    parent_response = parent_response[i:len(parent_response)]
+                    parent_response = parent_response[i:]
                     continue
 
 

--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -1,6 +1,7 @@
 # pylint: disable=E1101,R0201,W0613
 
 #!/usr/bin/env python3
+import itertools
 import json
 import os
 import time
@@ -369,8 +370,6 @@ class Stream():
     def transform(self, record):
         return humps.decamelize(record)
 
-    LOG_PROGRESS_PERCENTAGE_INTERVAL = 5
-
     def sync_substream(self, state, parent, sub_stream, parent_response):
         bookmark_date = self.get_bookmark(state, sub_stream.name,
                                           self.config.get('start_date'),
@@ -389,15 +388,13 @@ class Stream():
 
         # Slice response for >= last processed
         if last_processed:
-            for i, e in enumerate(parent_response):
+            for e in parent_response:
                 if e.get(parent.key_properties[0]) == last_processed:
                     LOGGER.info("Resuming %s sync with %s", sub_stream.name, e.get(parent.key_properties[0]))
-                    parent_response = parent_response[i:]
-                    continue
+                    parent_response = itertools.chain([e], parent_response)
+                    break
 
-
-        next_log_progress_percentage = 0
-        for index, record in enumerate(parent_response):
+        for record in parent_response:
             try:
                 with metrics.record_counter(
                         sub_stream.name) as counter, Transformer(
@@ -443,11 +440,6 @@ class Stream():
             # All events for all parents processed; can removed last processed
             self.update_bookmark(state=state, stream=sub_stream.name, bookmark_value=record.get(parent.key_properties[0]), bookmark_key="last_processed")
             self.update_bookmark(state=state, stream=sub_stream.name, bookmark_value=strftime(new_bookmark), bookmark_key=sub_stream.replication_key)
-
-            progress_percentage = float(index) / len(parent_response) * 100
-            if progress_percentage > next_log_progress_percentage:
-                LOGGER.info("Finished syncing %s percentage of sub_stream for parent %s's sub_stream %s data", progress_percentage, parent.name, sub_stream.name)
-                next_log_progress_percentage += self.LOG_PROGRESS_PERCENTAGE_INTERVAL
 
         # After processing for all parent ids we can remove our resumption state
         state.get('bookmarks').get(sub_stream.name).pop('last_processed')

--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -388,10 +388,14 @@ class Stream():
 
         # Slice response for >= last processed
         if last_processed:
+            ## TODO: What happens when there's a list that comes in here????
             for e in parent_response:
                 if e.get(parent.key_properties[0]) == last_processed:
                     LOGGER.info("Resuming %s sync with %s", sub_stream.name, e.get(parent.key_properties[0]))
-                    parent_response = itertools.chain([e], parent_response)
+                    if isinstance(parent_response, list):
+                        parent_response = parent_response[i:]
+                    else:
+                        parent_response = itertools.chain([e], parent_response)
                     break
 
         for record in parent_response:


### PR DESCRIPTION
# Description of change
Visitor history hits a sub-stream workflow that causes issues in the new generator pattern. There is no `len` with generators, so the progress report in the logs is not possible in the current structure.

This PR removes it and replaces it with code that works for both a generator and a list.

# Manual QA steps
 - Ran through a sync with visitors and visitor_history selected
 
# Risks
 - Low, it's currently broken for these streams
 
# Rollback steps
 - revert this branch
