### PR TITLE
Fix bookmark and replication key-properties

### DIFF
--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -602,8 +602,7 @@ class FeatureEvents(EventsBase):
         'server',
         'remote_ip',
         'feature_id',
-        'user_agent',
-        'app_id'
+        'user_agent'
     ]
 
     def get_body(self, key_id, period, first):
@@ -638,10 +637,7 @@ class Events(LazyAggregationStream):
         'account_id',
         'server',
         'remote_ip',
-        'feature_id',
-        'page_id',
-        'user_agent',
-        'app_id'
+        'user_agent'
     ]
     replication_method = "INCREMENTAL"
 
@@ -696,17 +692,7 @@ class Events(LazyAggregationStream):
 class PollEvents(Stream):
     replication_method = "INCREMENTAL"
     name = "poll_events"
-    key_properties = [
-        'visitor_id',
-        'account_id',
-        'server',
-        'remote_ip',
-        'poll_id',
-        'type',
-        'guide_id',
-        'user_agent',
-        'app_id'
-    ]
+    key_properties = []
 
     def __init__(self, config):
         super().__init__(config=config)
@@ -762,8 +748,7 @@ class TrackEvents(EventsBase):
         'server',
         'remote_ip',
         'track_type_id',
-        'user_agent',
-        'app_id'
+        'user_agent'
     ]
 
 
@@ -793,17 +778,7 @@ class TrackEvents(EventsBase):
 class GuideEvents(EventsBase):
     replication_method = "INCREMENTAL"
     name = "guide_events"
-    key_properties = [
-        'visitor_id',
-        'account_id',
-        'server',
-        'remote_ip',
-        'feature_id',
-        'poll_id',
-        'type',
-        'user_agent',
-        'app_id'
-    ]
+    key_properties = []
 
     def __init__(self, config):
         super().__init__(config=config)
@@ -923,10 +898,8 @@ class PageEvents(EventsBase):
         'account_id',
         'server',
         'remote_ip',
-        'feature_id',
         'page_id',
-        'user_agent',
-        'app_id'
+        'user_agent'
     ]
 
     def get_body(self, key_id, period, first):

--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -338,8 +338,13 @@ class Stream():
         schema = self.load_schema()
         mdata = metadata.new()
 
+        table_key_properties = self.key_properties + (
+            [self.replication_key]
+            if self.replication_key == 'day' or self.replication_key == 'hour'
+            else []
+        )
         mdata = metadata.write(mdata, (), 'table-key-properties',
-                               self.key_properties)
+                               table_key_properties)
         mdata = metadata.write(mdata, (), 'forced-replication-method',
                                self.replication_method)
 
@@ -591,7 +596,15 @@ class Features(Stream):
 class FeatureEvents(EventsBase):
     name = "feature_events"
     replication_method = "INCREMENTAL"
-    key_properties = ['visitor_id', 'account_id', 'server', 'remote_ip']
+    key_properties = [
+        'visitor_id',
+        'account_id',
+        'server',
+        'remote_ip',
+        'feature_id',
+        'user_agent',
+        'app_id'
+    ]
 
     def get_body(self, key_id, period, first):
         return {
@@ -620,7 +633,16 @@ class FeatureEvents(EventsBase):
 class Events(LazyAggregationStream):
     name = "events"
     DATE_WINDOW_SIZE = 1
-    key_properties = ['visitor_id', 'account_id', 'server', 'remote_ip']
+    key_properties = [
+        'visitor_id',
+        'account_id',
+        'server',
+        'remote_ip',
+        'feature_id',
+        'page_id',
+        'user_agent',
+        'app_id'
+    ]
     replication_method = "INCREMENTAL"
 
     def __init__(self, config):
@@ -674,7 +696,17 @@ class Events(LazyAggregationStream):
 class PollEvents(Stream):
     replication_method = "INCREMENTAL"
     name = "poll_events"
-    key_properties = ['visitor_id', 'account_id', 'server_name', 'remote_ip']
+    key_properties = [
+        'visitor_id',
+        'account_id',
+        'server',
+        'remote_ip',
+        'poll_id',
+        'type',
+        'guide_id',
+        'user_agent',
+        'app_id'
+    ]
 
     def __init__(self, config):
         super().__init__(config=config)
@@ -724,7 +756,15 @@ class PollEvents(Stream):
 class TrackEvents(EventsBase):
     replication_method = "INCREMENTAL"
     name = "track_events"
-    key_properties = ['visitor_id', 'account_id', 'server', 'remote_ip']
+    key_properties = [
+        'visitor_id',
+        'account_id',
+        'server',
+        'remote_ip',
+        'track_type_id',
+        'user_agent',
+        'app_id'
+    ]
 
 
     def get_body(self, key_id, period, first):
@@ -753,7 +793,17 @@ class TrackEvents(EventsBase):
 class GuideEvents(EventsBase):
     replication_method = "INCREMENTAL"
     name = "guide_events"
-    key_properties = ['visitor_id', 'account_id', 'server_name', 'remote_ip']
+    key_properties = [
+        'visitor_id',
+        'account_id',
+        'server',
+        'remote_ip',
+        'feature_id',
+        'poll_id',
+        'type',
+        'user_agent',
+        'app_id'
+    ]
 
     def __init__(self, config):
         super().__init__(config=config)
@@ -868,7 +918,16 @@ class Pages(Stream):
 class PageEvents(EventsBase):
     name = "page_events"
     replication_method = "INCREMENTAL"
-    key_properties = ['visitor_id', 'account_id', 'server', 'remote_ip']
+    key_properties = [
+        'visitor_id',
+        'account_id',
+        'server',
+        'remote_ip',
+        'feature_id',
+        'page_id',
+        'user_agent',
+        'app_id'
+    ]
 
     def get_body(self, key_id, period, first):
         return {

--- a/tap_pendo/sync.py
+++ b/tap_pendo/sync.py
@@ -46,9 +46,6 @@ def sync_stream(state, start_date, instance):
             if record_timestamp > bookmark_dttm:
                 singer.write_record(stream.tap_stream_id, transformed_record)
                 counter.increment()
-            else:
-                singer.write_record(stream.tap_stream_id, transformed_record)
-                counter.increment()
 
         instance.update_bookmark(state, instance.name, strftime(new_bookmark),
                                  instance.replication_key)


### PR DESCRIPTION
# Description of change

Addressed the issues I created https://github.com/singer-io/tap-pendo/issues/34 and https://github.com/singer-io/tap-pendo/issues/33 

I basically remove the else in this control flow:
```
if record_timestamp > bookmark_dttm:
      singer.write_record(stream.tap_stream_id, transformed_record)
      counter.increment()
  else:
      singer.write_record(stream.tap_stream_id, transformed_record)
      counter.increment()
```

Since it does not make sense. `if A do B, else do B too`. This was causing some tables to be fully replicated every time (like accounts, visitors, etc).

I also added the day/hour as a key along with several others for the event-based tables, this new keys are necessary to keep track of all the events and not ignore some of them due to primary key constraints. 
This change follows the [pendo documentation for grouped events](https://developers.pendo.io/docs/?bash#events-grouped)
for `Events, FeatureEvents, PageEvents and TrackEvents` and [the documentation for ungrouped events](https://developers.pendo.io/docs/?bash#events-ungrouped) for `PollEvents and GuideEvents`

# Manual QA steps
 - Discover the catalog `tap-pendo --config tap_config.json --catalog catalog.json > state.json`
 - Run `pylint tap_pendo -d missing-docstring -d logging-format-interpolation -d too-many-locals -d too-many-arguments`
```
   ************* Module tap_pendo
tap_pendo/__init__.py:104:2: W0511: TODO: sync code for stream goes here... (fixme)
************* Module tap_pendo.discover
tap_pendo/discover.py:53:4: R1705: Unnecessary "elif" after "return" (no-else-return)
tap_pendo/discover.py:109:8: C0103: Variable name "s" doesn't conform to snake_case naming style (invalid-name)
tap_pendo/discover.py:111:8: C0103: Variable name "s" doesn't conform to snake_case naming style (invalid-name)
************* Module tap_pendo.streams
tap_pendo/streams.py:236:0: C0301: Line too long (104/100) (line-too-long)
tap_pendo/streams.py:397:0: C0301: Line too long (116/100) (line-too-long)
tap_pendo/streams.py:449:0: C0301: Line too long (153/100) (line-too-long)
tap_pendo/streams.py:450:0: C0301: Line too long (149/100) (line-too-long)
tap_pendo/streams.py:474:0: C0301: Line too long (116/100) (line-too-long)
tap_pendo/streams.py:1025:0: C0301: Line too long (115/100) (line-too-long)
tap_pendo/streams.py:1:0: C0302: Too many lines in module (1135/1000) (too-many-lines)
tap_pendo/streams.py:317:19: C0103: Variable name "v" doesn't conform to snake_case naming style (invalid-name)
tap_pendo/streams.py:329:48: C0103: Variable name "f" doesn't conform to snake_case naming style (invalid-name)
tap_pendo/streams.py:522:8: C0103: Variable name "ts" doesn't conform to snake_case naming style (invalid-name)
tap_pendo/streams.py:662:8: C0103: Variable name "ts" doesn't conform to snake_case naming style (invalid-name)
tap_pendo/streams.py:747:8: C0103: Variable name "ts" doesn't conform to snake_case naming style (invalid-name)
tap_pendo/streams.py:998:12: C0103: Variable name "ts" doesn't conform to snake_case naming style (invalid-name)
************* Module tap_pendo.utils
tap_pendo/utils.py:12:0: C0103: Argument name "dt" doesn't conform to snake_case naming style (invalid-name)
tap_pendo/utils.py:16:0: C0103: Argument name "dt" doesn't conform to snake_case naming style (invalid-name)
tap_pendo/utils.py:21:4: C0103: Argument name "fn" doesn't conform to snake_case naming style (invalid-name)
tap_pendo/utils.py:27:16: C0103: Variable name "t0" doesn't conform to snake_case naming style (invalid-name)
tap_pendo/utils.py:28:16: C0103: Variable name "t" doesn't conform to snake_case naming style (invalid-name)
tap_pendo/utils.py:41:0: C0103: Argument name "l" doesn't conform to snake_case naming style (invalid-name)
tap_pendo/utils.py:41:0: C0103: Argument name "n" doesn't conform to snake_case naming style (invalid-name)
tap_pendo/utils.py:51:23: C0103: Variable name "f" doesn't conform to snake_case naming style (invalid-name)
tap_pendo/utils.py:59:0: C0103: Argument name "dt" doesn't conform to snake_case naming style (invalid-name)

-----------------------------------
Your code has been rated at 9.64/10
```
 - Check the tap is working `tap-pendo --config tap_config.json --catalog catalog.json | singer-check-tap > state.json`
 
```
cat state.json
Checking stdin for valid Singer-formatted data
The output is valid.
It contained 32240 messages for 12 streams.

     16 schema messages
  31279 record messages
    945 state messages

Details by stream:
+----------------+---------+---------+
| stream         | records | schemas |
+----------------+---------+---------+
| accounts       | 966     | 1       |
| features       | 14      | 1       |
| feature_events | 2659    | 2       |
| guides         | 8       | 1       |
| guide_events   | 0       | 2       |
| pages          | 1       | 1       |
| page_events    | 2572    | 2       |
| visitors       | 104     | 1       |
| events         | 568     | 1       |
| poll_events    | 0       | 1       |
| track_types    | 0       | 1       |
| track_events   | 24387   | 2       |
+----------------+---------+---------+
```

# Risks
 - 
 
# Rollback steps
 - revert this branch
