### PR TITLE
bumped version to 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.0
+  * Added support for custom field of type "int" and of type empty string [#37](https://github.com/singer-io/tap-pendo/pull/37)
+
 ## 0.0.15
   * Add optional sync for anonymous Visitors
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-pendo",
-    version="0.0.15",
+    version="0.1.0",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="https://github.com/singer-io/tap-pendo",


### PR DESCRIPTION
# Description of change
bumped version to 0.1.0

# Manual QA steps
 - on the actual change, (https://github.com/singer-io/tap-pendo/pull/37), I ran discovery and sync manually to make sure it exited succesfully
 
# Risks
 - low
 
# Rollback steps
 - revert this branch
