### PR TITLE
TDL-14913: Add retry logic to requests and TDL-14884: Add timeouts and retries to requests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,13 @@ jobs:
           name: 'Unit Tests'
           command: |
             source /usr/local/share/virtualenvs/tap-pendo/bin/activate
-            nosetests tests/unittests
+            pip install coverage
+            nosetests --with-coverage --cover-erase --cover-package=tap_pendo --cover-html-dir=htmlcov tests/unittests
+            coverage html
+      - store_test_results:
+          path: test_output/report.xml
+      - store_artifacts:
+          path: htmlcov
       - add_ssh_keys
       - run:
           name: 'Integration Tests'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,11 @@ jobs:
             source /usr/local/share/virtualenvs/tap-pendo/bin/activate
             # TODO: Adjust the pylint disables
             pylint tap_pendo --disable 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,bad-whitespace,missing-class-docstring'
+      - run:
+          name: 'Unit Tests'
+          command: |
+            source /usr/local/share/virtualenvs/tap-pendo/bin/activate
+            nosetests tests/unittests
       - add_ssh_keys
       - run:
           name: 'Integration Tests'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
             python3 -mvenv /usr/local/share/virtualenvs/tap-pendo
             source /usr/local/share/virtualenvs/tap-pendo/bin/activate
             pip install -U pip setuptools
-            pip install .[dev]
+            pip install .[test]
       - run:
           name: 'JSON Validator'
           command: |

--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ Interrupted syncs for Event type stream are resumed via a bookmark placed during
    - `x_pendo_integration_key` (string, `ABCdef123`): an integration key from Pendo.
    - `period` (string, `ABCdef123`): `dayRange` or `hourRange`
    - `lookback_window` (integer): 10 (For event objects. Default: 0)
+   - `request_timeout` (integer): 100 (For passing timeout to the request. Default: 300)
 
    ```json
    {
@@ -252,6 +253,7 @@ Interrupted syncs for Event type stream are resumed via a bookmark placed during
      "start_date": "2020-09-18T00:00:00Z",
      "period": "dayRange",
      "lookback_window": 10,
+     "request_timeout": 100,
      "include_anonymous_visitors: "true"
    }
    ```

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Interrupted syncs for Event type stream are resumed via a bookmark placed during
    - `x_pendo_integration_key` (string, `ABCdef123`): an integration key from Pendo.
    - `period` (string, `ABCdef123`): `dayRange` or `hourRange`
    - `lookback_window` (integer): 10 (For event objects. Default: 0)
-   - `request_timeout` (integer): 100 (For passing timeout to the request. Default: 300)
+   - `request_timeout` (integer): 300 (For passing timeout to the request. Default: 300)
 
    ```json
    {
@@ -253,7 +253,7 @@ Interrupted syncs for Event type stream are resumed via a bookmark placed during
      "start_date": "2020-09-18T00:00:00Z",
      "period": "dayRange",
      "lookback_window": 10,
-     "request_timeout": 100,
+     "request_timeout": 300,
      "include_anonymous_visitors: "true"
    }
    ```

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,12 @@ setup(
         'ijson==3.1.4',
     ],
     extras_require={
-        'dev': [
-            'ipdb==0.11',
+        'test': [
             'pylint==2.5.3',
+            'nose'
+        ],
+        'dev': [
+            'ipdb==0.11'
         ]
     },
     entry_points="""

--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -22,6 +22,9 @@ from tap_pendo import utils as tap_pendo_utils
 KEY_PROPERTIES = ['id']
 BASE_URL = "https://app.pendo.io"
 
+# timeout request after 300 seconds
+REQUEST_TIMEOUT = 300
+
 endpoints = {
     "account": {
         "method": "GET",
@@ -220,7 +223,7 @@ class Stream():
         self.config = config
 
     def send_request_get_results(self, req):
-        resp = session.send(req, timeout=300)
+        resp = session.send(req, timeout=REQUEST_TIMEOUT)
 
         if 'Too Many Requests' in resp.reason:
             retry_after = 30

--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -226,7 +226,7 @@ class Stream():
         # Set request timeout to config param `request_timeout` value.
         # If value is 0,"0", "" or None then it will set default to default to 300.0 seconds if not passed in config.
         config_request_timeout = self.config.get('request_timeout')
-        request_timeout = float(config_request_timeout) if config_request_timeout else REQUEST_TIMEOUT
+        request_timeout = config_request_timeout and float(config_request_timeout) or REQUEST_TIMEOUT # pylint: disable=consider-using-ternary
         resp = session.send(req, timeout=request_timeout)
 
         if 'Too Many Requests' in resp.reason:
@@ -489,7 +489,7 @@ class LazyAggregationStream(Stream):
         # Set request timeout to config param `request_timeout` value.
         # If value is 0,"0", "" or None then it will set default to default to 300.0 seconds if not passed in config.
         config_request_timeout = self.config.get('request_timeout')
-        request_timeout = float(config_request_timeout) if config_request_timeout else REQUEST_TIMEOUT
+        request_timeout = config_request_timeout and float(config_request_timeout) or REQUEST_TIMEOUT # pylint: disable=consider-using-ternary
         with session.send(req, stream=True, timeout=request_timeout) as resp:
             if 'Too Many Requests' in resp.reason:
                 retry_after = 30

--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -224,7 +224,7 @@ class Stream():
 
     def send_request_get_results(self, req):
         # add timeout if 'request_timeout' param found in else use default value
-        resp = session.send(req, timeout=float(self.config.get('request_timeout', REQUEST_TIMEOUT)))
+        resp = session.send(req, timeout=float(self.config.get('request_timeout') or REQUEST_TIMEOUT))
 
         if 'Too Many Requests' in resp.reason:
             retry_after = 30
@@ -484,7 +484,7 @@ class Stream():
 class LazyAggregationStream(Stream):
     def send_request_get_results(self, req):
         # add timeout if 'request_timeout' param found in else use default value
-        with session.send(req, stream=True, timeout=float(self.config.get('request_timeout', REQUEST_TIMEOUT))) as resp:
+        with session.send(req, stream=True, timeout=float(self.config.get('request_timeout') or REQUEST_TIMEOUT)) as resp:
             if 'Too Many Requests' in resp.reason:
                 retry_after = 30
                 LOGGER.info("Rate limit reached. Sleeping for %s seconds",

--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -223,7 +223,8 @@ class Stream():
         self.config = config
 
     def send_request_get_results(self, req):
-        resp = session.send(req, timeout=REQUEST_TIMEOUT)
+        # add timeout if 'request_timeout' param found in else use default value
+        resp = session.send(req, timeout=self.config.get('request_timeout', REQUEST_TIMEOUT))
 
         if 'Too Many Requests' in resp.reason:
             retry_after = 30
@@ -242,7 +243,7 @@ class Stream():
                           giveup=lambda e: e.response is not None and 400 <= e.
                           response.status_code < 500,
                           factor=2)
-    @backoff.on_exception(backoff.expo, (ConnectionError, ProtocolError),
+    @backoff.on_exception(backoff.expo, (ConnectionError, ProtocolError), # backoff error
                           max_tries=5,
                           factor=2)
     @tap_pendo_utils.ratelimit(1, 2)

--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -224,7 +224,7 @@ class Stream():
 
     def send_request_get_results(self, req):
         # add timeout if 'request_timeout' param found in else use default value
-        resp = session.send(req, timeout=self.config.get('request_timeout', REQUEST_TIMEOUT))
+        resp = session.send(req, timeout=float(self.config.get('request_timeout', REQUEST_TIMEOUT)))
 
         if 'Too Many Requests' in resp.reason:
             retry_after = 30
@@ -484,7 +484,7 @@ class Stream():
 class LazyAggregationStream(Stream):
     def send_request_get_results(self, req):
         # add timeout if 'request_timeout' param found in else use default value
-        with session.send(req, stream=True, timeout=self.config.get('request_timeout', REQUEST_TIMEOUT)) as resp:
+        with session.send(req, stream=True, timeout=float(self.config.get('request_timeout', REQUEST_TIMEOUT))) as resp:
             if 'Too Many Requests' in resp.reason:
                 retry_after = 30
                 LOGGER.info("Rate limit reached. Sleeping for %s seconds",

--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -226,7 +226,7 @@ class Stream():
         # Set request timeout to config param `request_timeout` value.
         # If value is 0,"0", "" or None then it will set default to default to 300.0 seconds if not passed in config.
         config_request_timeout = self.config.get('request_timeout')
-        request_timeout = config_request_timeout and float(config_request_timeout) or REQUEST_TIMEOUT
+        request_timeout = float(config_request_timeout) if config_request_timeout else REQUEST_TIMEOUT
         resp = session.send(req, timeout=request_timeout)
 
         if 'Too Many Requests' in resp.reason:
@@ -489,7 +489,7 @@ class LazyAggregationStream(Stream):
         # Set request timeout to config param `request_timeout` value.
         # If value is 0,"0", "" or None then it will set default to default to 300.0 seconds if not passed in config.
         config_request_timeout = self.config.get('request_timeout')
-        request_timeout = config_request_timeout and float(config_request_timeout) or REQUEST_TIMEOUT
+        request_timeout = float(config_request_timeout) if config_request_timeout else REQUEST_TIMEOUT
         with session.send(req, stream=True, timeout=request_timeout) as resp:
             if 'Too Many Requests' in resp.reason:
                 retry_after = 30

--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -223,8 +223,11 @@ class Stream():
         self.config = config
 
     def send_request_get_results(self, req):
-        # add timeout if 'request_timeout' param found in else use default value
-        resp = session.send(req, timeout=float(self.config.get('request_timeout') or REQUEST_TIMEOUT))
+        # Set request timeout to config param `request_timeout` value.
+        # If value is 0,"0", "" or None then it will set default to default to 300.0 seconds if not passed in config.
+        config_request_timeout = self.config.get('request_timeout')
+        request_timeout = config_request_timeout and float(config_request_timeout) or REQUEST_TIMEOUT
+        resp = session.send(req, timeout=request_timeout)
 
         if 'Too Many Requests' in resp.reason:
             retry_after = 30
@@ -483,8 +486,11 @@ class Stream():
 
 class LazyAggregationStream(Stream):
     def send_request_get_results(self, req):
-        # add timeout if 'request_timeout' param found in else use default value
-        with session.send(req, stream=True, timeout=float(self.config.get('request_timeout') or REQUEST_TIMEOUT)) as resp:
+        # Set request timeout to config param `request_timeout` value.
+        # If value is 0,"0", "" or None then it will set default to default to 300.0 seconds if not passed in config.
+        config_request_timeout = self.config.get('request_timeout')
+        request_timeout = config_request_timeout and float(config_request_timeout) or REQUEST_TIMEOUT
+        with session.send(req, stream=True, timeout=request_timeout) as resp:
             if 'Too Many Requests' in resp.reason:
                 retry_after = 30
                 LOGGER.info("Rate limit reached. Sleeping for %s seconds",

--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -481,7 +481,8 @@ class Stream():
 
 class LazyAggregationStream(Stream):
     def send_request_get_results(self, req):
-        with session.send(req, stream=True, timeout=300) as resp:
+        # add timeout if 'request_timeout' param found in else use default value
+        with session.send(req, stream=True, timeout=self.config.get('request_timeout', REQUEST_TIMEOUT)) as resp:
             if 'Too Many Requests' in resp.reason:
                 retry_after = 30
                 LOGGER.info("Rate limit reached. Sleeping for %s seconds",

--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -238,6 +238,8 @@ class Stream():
         dec = humps.decamelize(resp.json())
         return dec
 
+    # backoff for Timeout error is already included in "requests.exceptions.RequestException"
+    # as it is the parent class of "Timeout" error
     @backoff.on_exception(backoff.expo, (requests.exceptions.RequestException, Server42xRateLimitError),
                           max_tries=5,
                           giveup=lambda e: e.response is not None and 400 <= e.

--- a/tests/unittests/test_backoff.py
+++ b/tests/unittests/test_backoff.py
@@ -37,8 +37,10 @@ def get_response(json={}):
 class TestTimeOut(unittest.TestCase):
 
     def test_timeout__accounts(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = requests.exceptions.Timeout
 
+        # initialize 'accounts' stream class
         accounts = streams.Accounts({'x_pendo_integration_key': 'test'})
 
         try:
@@ -46,11 +48,14 @@ class TestTimeOut(unittest.TestCase):
         except requests.exceptions.Timeout:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
     def test_timeout__features(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = requests.exceptions.Timeout
 
+        # initialize 'features' stream class
         features = streams.Features({'x_pendo_integration_key': 'test'})
 
         try:
@@ -58,11 +63,14 @@ class TestTimeOut(unittest.TestCase):
         except requests.exceptions.Timeout:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
     def test_timeout__guides(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = requests.exceptions.Timeout
 
+        # initialize 'guides' stream class
         guides = streams.Guides({'x_pendo_integration_key': 'test'})
 
         try:
@@ -70,11 +78,14 @@ class TestTimeOut(unittest.TestCase):
         except requests.exceptions.Timeout:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
     def test_timeout__pages(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = requests.exceptions.Timeout
 
+        # initialize 'pages' stream class
         pages = streams.Pages({'x_pendo_integration_key': 'test'})
 
         try:
@@ -82,11 +93,14 @@ class TestTimeOut(unittest.TestCase):
         except requests.exceptions.Timeout:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
     def test_timeout__feature_events(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = requests.exceptions.Timeout
 
+        # initialize 'feature_events' stream class
         feature_events = streams.FeatureEvents({'x_pendo_integration_key': 'test'})
 
         try:
@@ -94,11 +108,14 @@ class TestTimeOut(unittest.TestCase):
         except requests.exceptions.Timeout:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
     def test_timeout__page_events(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = requests.exceptions.Timeout
 
+        # initialize 'page_events' stream class
         page_events = streams.PageEvents({'x_pendo_integration_key': 'test'})
 
         try:
@@ -106,11 +123,14 @@ class TestTimeOut(unittest.TestCase):
         except requests.exceptions.Timeout:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
     def test_timeout__guide_events(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = requests.exceptions.Timeout
 
+        # initialize 'guide_events' stream class
         guide_events = streams.GuideEvents({'x_pendo_integration_key': 'test'})
 
         try:
@@ -118,11 +138,14 @@ class TestTimeOut(unittest.TestCase):
         except requests.exceptions.Timeout:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
     def test_timeout__poll_events(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = requests.exceptions.Timeout
 
+        # initialize 'poll_events' stream class
         poll_events = streams.PollEvents({'x_pendo_integration_key': 'test'})
 
         try:
@@ -130,11 +153,14 @@ class TestTimeOut(unittest.TestCase):
         except requests.exceptions.Timeout:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
     def test_timeout__track_types(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = requests.exceptions.Timeout
 
+        # initialize 'track_types' stream class
         track_types = streams.TrackTypes({'x_pendo_integration_key': 'test'})
 
         try:
@@ -142,11 +168,14 @@ class TestTimeOut(unittest.TestCase):
         except requests.exceptions.Timeout:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
     def test_timeout__track_events(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = requests.exceptions.Timeout
 
+        # initialize 'track_events' stream class
         track_events = streams.TrackEvents({'x_pendo_integration_key': 'test'})
 
         try:
@@ -154,11 +183,14 @@ class TestTimeOut(unittest.TestCase):
         except requests.exceptions.Timeout:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
     def test_timeout__metadata_accounts(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = requests.exceptions.Timeout
 
+        # initialize 'metadata_accounts' stream class
         metadata_accounts = streams.MetadataAccounts({'x_pendo_integration_key': 'test'})
 
         try:
@@ -166,12 +198,14 @@ class TestTimeOut(unittest.TestCase):
         except requests.exceptions.Timeout:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
-    
     def test_timeout__metadata_visitors(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = requests.exceptions.Timeout
 
+        # initialize 'metadata_visitors' stream class
         metadata_visitors = streams.MetadataVisitors({'x_pendo_integration_key': 'test'})
 
         try:
@@ -179,11 +213,14 @@ class TestTimeOut(unittest.TestCase):
         except requests.exceptions.Timeout:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
-    def test_timeout__metadata_visitor_history(self, mocked_send, mocked_sleep):
+    def test_timeout__visitor_history(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = requests.exceptions.Timeout
 
+        # initialize 'visitor_history' stream class
         visitor_history = streams.VisitorHistory({'x_pendo_integration_key': 'test'})
 
         try:
@@ -191,11 +228,14 @@ class TestTimeOut(unittest.TestCase):
         except requests.exceptions.Timeout:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
     def test_timeout__visitors(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = requests.exceptions.Timeout
 
+        # initialize 'visitors' stream class
         visitors = streams.Visitors({'x_pendo_integration_key': 'test'})
 
         try:
@@ -203,11 +243,14 @@ class TestTimeOut(unittest.TestCase):
         except requests.exceptions.Timeout:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
     def test_timeout__events(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = requests.exceptions.Timeout
 
+        # initialize 'events' stream class
         events = streams.Events({'x_pendo_integration_key': 'test'})
 
         try:
@@ -215,6 +258,7 @@ class TestTimeOut(unittest.TestCase):
         except requests.exceptions.Timeout:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
 @mock.patch("time.sleep")
@@ -222,8 +266,10 @@ class TestTimeOut(unittest.TestCase):
 class TestConnectionResetError(unittest.TestCase):
 
     def test_connection_reset_error__accounts(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = socket.error(104, 'Connection reset by peer')
 
+        # initialize 'accounts' stream class
         accounts = streams.Accounts({'x_pendo_integration_key': 'test'})
 
         try:
@@ -231,11 +277,14 @@ class TestConnectionResetError(unittest.TestCase):
         except ConnectionResetError:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
     def test_connection_reset_error__features(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = socket.error(104, 'Connection reset by peer')
 
+        # initialize 'features' stream class
         features = streams.Features({'x_pendo_integration_key': 'test'})
 
         try:
@@ -243,11 +292,14 @@ class TestConnectionResetError(unittest.TestCase):
         except ConnectionResetError:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
     def test_connection_reset_error__guides(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = socket.error(104, 'Connection reset by peer')
 
+        # initialize 'guides' stream class
         guides = streams.Guides({'x_pendo_integration_key': 'test'})
 
         try:
@@ -255,11 +307,14 @@ class TestConnectionResetError(unittest.TestCase):
         except ConnectionResetError:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
     def test_connection_reset_error__pages(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = socket.error(104, 'Connection reset by peer')
 
+        # initialize 'pages' stream class
         pages = streams.Pages({'x_pendo_integration_key': 'test'})
 
         try:
@@ -267,11 +322,14 @@ class TestConnectionResetError(unittest.TestCase):
         except ConnectionResetError:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
     def test_connection_reset_error__feature_events(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = socket.error(104, 'Connection reset by peer')
 
+        # initialize 'feature_events' stream class
         feature_events = streams.FeatureEvents({'x_pendo_integration_key': 'test'})
 
         try:
@@ -279,11 +337,14 @@ class TestConnectionResetError(unittest.TestCase):
         except ConnectionResetError:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
     def test_connection_reset_error__page_events(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = socket.error(104, 'Connection reset by peer')
 
+        # initialize 'page_events' stream class
         page_events = streams.PageEvents({'x_pendo_integration_key': 'test'})
 
         try:
@@ -291,11 +352,14 @@ class TestConnectionResetError(unittest.TestCase):
         except ConnectionResetError:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
     def test_connection_reset_error__guide_events(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = socket.error(104, 'Connection reset by peer')
 
+        # initialize 'guide_events' stream class
         guide_events = streams.GuideEvents({'x_pendo_integration_key': 'test'})
 
         try:
@@ -303,11 +367,14 @@ class TestConnectionResetError(unittest.TestCase):
         except ConnectionResetError:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
     def test_connection_reset_error__poll_events(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = socket.error(104, 'Connection reset by peer')
 
+        # initialize 'poll_events' stream class
         poll_events = streams.PollEvents({'x_pendo_integration_key': 'test'})
 
         try:
@@ -315,11 +382,14 @@ class TestConnectionResetError(unittest.TestCase):
         except ConnectionResetError:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
     def test_connection_reset_error__track_types(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = socket.error(104, 'Connection reset by peer')
 
+        # initialize 'track_types' stream class
         track_types = streams.TrackTypes({'x_pendo_integration_key': 'test'})
 
         try:
@@ -327,11 +397,14 @@ class TestConnectionResetError(unittest.TestCase):
         except ConnectionResetError:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
     def test_connection_reset_error__track_events(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = socket.error(104, 'Connection reset by peer')
 
+        # initialize 'track_events' stream class
         track_events = streams.TrackEvents({'x_pendo_integration_key': 'test'})
 
         try:
@@ -339,11 +412,14 @@ class TestConnectionResetError(unittest.TestCase):
         except ConnectionResetError:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
     def test_connection_reset_error__metadata_accounts(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = socket.error(104, 'Connection reset by peer')
 
+        # initialize 'metadata_accounts' stream class
         metadata_accounts = streams.MetadataAccounts({'x_pendo_integration_key': 'test'})
 
         try:
@@ -351,12 +427,14 @@ class TestConnectionResetError(unittest.TestCase):
         except ConnectionResetError:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
-    
     def test_connection_reset_error__metadata_visitors(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = socket.error(104, 'Connection reset by peer')
 
+        # initialize 'metadata_visitors' stream class
         metadata_visitors = streams.MetadataVisitors({'x_pendo_integration_key': 'test'})
 
         try:
@@ -364,12 +442,14 @@ class TestConnectionResetError(unittest.TestCase):
         except ConnectionResetError:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
-
-    def test_connection_reset_error__metadata_visitor_history(self, mocked_send, mocked_sleep):
+    def test_connection_reset_error__visitor_history(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = socket.error(104, 'Connection reset by peer')
 
+        # initialize 'visitor_history' stream class
         visitor_history = streams.VisitorHistory({'x_pendo_integration_key': 'test'})
 
         try:
@@ -377,11 +457,14 @@ class TestConnectionResetError(unittest.TestCase):
         except ConnectionResetError:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
     def test_connection_reset_error__visitors(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = socket.error(104, 'Connection reset by peer')
 
+        # initialize 'visitors' stream class
         visitors = streams.Visitors({'x_pendo_integration_key': 'test'})
 
         try:
@@ -389,11 +472,14 @@ class TestConnectionResetError(unittest.TestCase):
         except ConnectionResetError:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
     def test_connection_reset_error__events(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = socket.error(104, 'Connection reset by peer')
 
+        # initialize 'events' stream class
         events = streams.Events({'x_pendo_integration_key': 'test'})
 
         try:
@@ -401,6 +487,7 @@ class TestConnectionResetError(unittest.TestCase):
         except ConnectionResetError:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
 @mock.patch("time.sleep")
@@ -408,8 +495,10 @@ class TestConnectionResetError(unittest.TestCase):
 class TestProtocolError(unittest.TestCase):
 
     def test_protocol_error__accounts(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = ProtocolError("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
 
+        # initialize 'accounts' stream class
         accounts = streams.Accounts({'x_pendo_integration_key': 'test'})
 
         try:
@@ -417,11 +506,14 @@ class TestProtocolError(unittest.TestCase):
         except ProtocolError:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
     def test_protocol_error__features(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = ProtocolError("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
 
+        # initialize 'features' stream class
         features = streams.Features({'x_pendo_integration_key': 'test'})
 
         try:
@@ -429,11 +521,14 @@ class TestProtocolError(unittest.TestCase):
         except ProtocolError:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
     def test_protocol_error__guides(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = ProtocolError("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
 
+        # initialize 'guides' stream class
         guides = streams.Guides({'x_pendo_integration_key': 'test'})
 
         try:
@@ -441,11 +536,14 @@ class TestProtocolError(unittest.TestCase):
         except ProtocolError:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
     def test_protocol_error__pages(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = ProtocolError("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
 
+        # initialize 'pages' stream class
         pages = streams.Pages({'x_pendo_integration_key': 'test'})
 
         try:
@@ -453,11 +551,14 @@ class TestProtocolError(unittest.TestCase):
         except ProtocolError:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
     def test_protocol_error__feature_events(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = ProtocolError("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
 
+        # initialize 'feature_events' stream class
         feature_events = streams.FeatureEvents({'x_pendo_integration_key': 'test'})
 
         try:
@@ -465,11 +566,14 @@ class TestProtocolError(unittest.TestCase):
         except ProtocolError:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
     def test_protocol_error__page_events(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = ProtocolError("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
 
+        # initialize 'page_events' stream class
         page_events = streams.PageEvents({'x_pendo_integration_key': 'test'})
 
         try:
@@ -477,11 +581,14 @@ class TestProtocolError(unittest.TestCase):
         except ProtocolError:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
     def test_protocol_error__guide_events(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = ProtocolError("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
 
+        # initialize 'guide_events' stream class
         guide_events = streams.GuideEvents({'x_pendo_integration_key': 'test'})
 
         try:
@@ -489,11 +596,14 @@ class TestProtocolError(unittest.TestCase):
         except ProtocolError:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
     def test_protocol_error__poll_events(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = ProtocolError("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
 
+        # initialize 'poll_events' stream class
         poll_events = streams.PollEvents({'x_pendo_integration_key': 'test'})
 
         try:
@@ -501,11 +611,14 @@ class TestProtocolError(unittest.TestCase):
         except ProtocolError:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
     def test_protocol_error__track_types(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = ProtocolError("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
 
+        # initialize 'track_types' stream class
         track_types = streams.TrackTypes({'x_pendo_integration_key': 'test'})
 
         try:
@@ -513,11 +626,14 @@ class TestProtocolError(unittest.TestCase):
         except ProtocolError:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
     def test_protocol_error__track_events(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = ProtocolError("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
 
+        # initialize 'track_events' stream class
         track_events = streams.TrackEvents({'x_pendo_integration_key': 'test'})
 
         try:
@@ -525,11 +641,14 @@ class TestProtocolError(unittest.TestCase):
         except ProtocolError:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
     def test_protocol_error__metadata_accounts(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = ProtocolError("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
 
+        # initialize 'metadata_accounts' stream class
         metadata_accounts = streams.MetadataAccounts({'x_pendo_integration_key': 'test'})
 
         try:
@@ -537,12 +656,14 @@ class TestProtocolError(unittest.TestCase):
         except ProtocolError:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
-    
     def test_protocol_error__metadata_visitors(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = ProtocolError("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
 
+        # initialize 'metadata_visitors' stream class
         metadata_visitors = streams.MetadataVisitors({'x_pendo_integration_key': 'test'})
 
         try:
@@ -550,12 +671,14 @@ class TestProtocolError(unittest.TestCase):
         except ProtocolError:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
-
-    def test_protocol_error__metadata_visitor_history(self, mocked_send, mocked_sleep):
+    def test_protocol_error__visitor_history(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = ProtocolError("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
 
+        # initialize 'visitor_history' stream class
         visitor_history = streams.VisitorHistory({'x_pendo_integration_key': 'test'})
 
         try:
@@ -563,11 +686,14 @@ class TestProtocolError(unittest.TestCase):
         except ProtocolError:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
     def test_protocol_error__visitors(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = ProtocolError("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
 
+        # initialize 'visitors' stream class
         visitors = streams.Visitors({'x_pendo_integration_key': 'test'})
 
         try:
@@ -575,11 +701,14 @@ class TestProtocolError(unittest.TestCase):
         except ProtocolError:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
     def test_protocol_error__events(self, mocked_send, mocked_sleep):
+        # mock request and raise error
         mocked_send.side_effect = ProtocolError("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
 
+        # initialize 'events' stream class
         events = streams.Events({'x_pendo_integration_key': 'test'})
 
         try:
@@ -587,6 +716,7 @@ class TestProtocolError(unittest.TestCase):
         except ProtocolError:
             pass
 
+        # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
 
 @mock.patch('requests.Session.send')
@@ -594,152 +724,195 @@ class Positive(unittest.TestCase):
 
     def test_positive__accounts(self, mocked_send):
         json = {"key1": "value1", "key2": "value2"}
+        # mock request and return dummy data
         mocked_send.return_value = get_response(json)
 
+        # initialize 'accounts' stream class
         accounts = streams.Accounts({'x_pendo_integration_key': 'test'})
 
         resp = accounts.request('accounts')
         
+        # verify if the desired data was returned from the request
         self.assertEquals(resp, json)
 
     def test_positive__features(self, mocked_send):
         json = {"key1": "value1", "key2": "value2"}
+        # mock request and return dummy data
         mocked_send.return_value = get_response(json)
 
+        # initialize 'features' stream class
         features = streams.Features({'x_pendo_integration_key': 'test'})
 
         resp = features.request('features')
         
+        # verify if the desired data was returned from the request
         self.assertEquals(resp, json)
 
     def test_positive__guides(self, mocked_send):
         json = {"key1": "value1", "key2": "value2"}
+        # mock request and return dummy data
         mocked_send.return_value = get_response(json)
 
+        # initialize 'guides' stream class
         guides = streams.Guides({'x_pendo_integration_key': 'test'})
 
         resp = guides.request('guides')
         
+        # verify if the desired data was returned from the request
         self.assertEquals(resp, json)
 
     def test_positive__pages(self, mocked_send):
         json = {"key1": "value1", "key2": "value2"}
+        # mock request and return dummy data
         mocked_send.return_value = get_response(json)
 
+        # initialize 'pages' stream class
         pages = streams.Pages({'x_pendo_integration_key': 'test'})
 
         resp = pages.request('pages')
         
+        # verify if the desired data was returned from the request
         self.assertEquals(resp, json)
 
     def test_positive__feature_events(self, mocked_send):
         json = {"key1": "value1", "key2": "value2"}
+        # mock request and return dummy data
         mocked_send.return_value = get_response(json)
 
+        # initialize 'feature_events' stream class
         feature_events = streams.FeatureEvents({'x_pendo_integration_key': 'test'})
 
         resp = feature_events.request('feature_events')
         
+        # verify if the desired data was returned from the request
         self.assertEquals(resp, json)
 
     def test_positive__page_events(self, mocked_send):
         json = {"key1": "value1", "key2": "value2"}
+        # mock request and return dummy data
         mocked_send.return_value = get_response(json)
 
+        # initialize 'page_events' stream class
         page_events = streams.PageEvents({'x_pendo_integration_key': 'test'})
 
         resp = page_events.request('page_events')
         
+        # verify if the desired data was returned from the request
         self.assertEquals(resp, json)
 
     def test_positive__guide_events(self, mocked_send):
         json = {"key1": "value1", "key2": "value2"}
+        # mock request and return dummy data
         mocked_send.return_value = get_response(json)
 
+        # initialize 'guide_events' stream class
         guide_events = streams.GuideEvents({'x_pendo_integration_key': 'test'})
 
         resp = guide_events.request('guide_events')
         
+        # verify if the desired data was returned from the request
         self.assertEquals(resp, json)
 
     def test_positive__poll_events(self, mocked_send):
         json = {"key1": "value1", "key2": "value2"}
+        # mock request and return dummy data
         mocked_send.return_value = get_response(json)
 
+        # initialize 'poll_events' stream class
         poll_events = streams.PollEvents({'x_pendo_integration_key': 'test'})
 
         resp = poll_events.request('poll_events')
         
+        # verify if the desired data was returned from the request
         self.assertEquals(resp, json)
 
     def test_positive__track_types(self, mocked_send):
         json = {"key1": "value1", "key2": "value2"}
+        # mock request and return dummy data
         mocked_send.return_value = get_response(json)
 
+        # initialize 'track_types' stream class
         track_types = streams.TrackTypes({'x_pendo_integration_key': 'test'})
 
         resp = track_types.request('track_types')
         
+        # verify if the desired data was returned from the request
         self.assertEquals(resp, json)
 
     def test_positive__track_events(self, mocked_send):
         json = {"key1": "value1", "key2": "value2"}
+        # mock request and return dummy data
         mocked_send.return_value = get_response(json)
 
+        # initialize 'track_events' stream class
         track_events = streams.TrackEvents({'x_pendo_integration_key': 'test'})
 
         resp = track_events.request('track_events')
         
+        # verify if the desired data was returned from the request
         self.assertEquals(resp, json)
 
     def test_positive__metadata_accounts(self, mocked_send):
         json = {"key1": "value1", "key2": "value2"}
+        # mock request and return dummy data
         mocked_send.return_value = get_response(json)
 
+        # initialize 'metadata_accounts' stream class
         metadata_accounts = streams.MetadataAccounts({'x_pendo_integration_key': 'test'})
 
         resp = metadata_accounts.request('metadata_accounts')
         
+        # verify if the desired data was returned from the request
         self.assertEquals(resp, json)
 
-    
     def test_positive__metadata_visitors(self, mocked_send):
         json = {"key1": "value1", "key2": "value2"}
+        # mock request and return dummy data
         mocked_send.return_value = get_response(json)
 
+        # initialize 'metadata_visitors' stream class
         metadata_visitors = streams.MetadataVisitors({'x_pendo_integration_key': 'test'})
 
         resp = metadata_visitors.request('metadata_visitors')
         
+        # verify if the desired data was returned from the request
         self.assertEquals(resp, json)
 
-
-    def test_positive__metadata_visitor_history(self, mocked_send):
+    def test_positive__visitor_history(self, mocked_send):
         json = {"key1": "value1", "key2": "value2"}
+        # mock request and return dummy data
         mocked_send.return_value = get_response(json)
 
+        # initialize 'visitor_history' stream class
         visitor_history = streams.VisitorHistory({'x_pendo_integration_key': 'test'})
 
         resp = visitor_history.request('visitor_history', visitorId=1)
         
+        # verify if the desired data was returned from the request
         self.assertEquals(resp, json)
 
     def test_positive__visitors(self, mocked_send):
         json = {"key1": "value1", "key2": "value2"}
+        # mock request and return dummy data
         mocked_send.return_value = get_response(json)
 
+        # initialize 'visitors' stream class
         visitors = streams.Visitors({'x_pendo_integration_key': 'test'})
 
         resp = visitors.request('visitors')
         
+        # verify if the desired data was returned from the request
         self.assertEquals(resp, [json])
 
     def test_positive__events(self, mocked_send):
         json = {"key1": "value1", "key2": "value2"}
+        # mock request and return dummy data
         mocked_send.return_value = get_response(json)
 
+        # initialize 'events' stream class
         events = streams.Events({'x_pendo_integration_key': 'test'})
 
         resp = events.request('events')
         
+        # verify if the desired data was returned from the request
         self.assertEquals(resp, [json])

--- a/tests/unittests/test_backoff.py
+++ b/tests/unittests/test_backoff.py
@@ -1,0 +1,745 @@
+import unittest
+import requests
+import socket
+from unittest import mock
+import tap_pendo.streams as streams
+from requests.models import ProtocolError
+
+class Mockresponse:
+    def __init__(self, status_code, json, raise_error, headers=None):
+        self.status_code = status_code
+        self.raise_error = raise_error
+        self.text = json
+        self.headers = headers
+        self.reason = "test"
+        self.raw = '{"results": [{"key1": "value1", "key2": "value2"}]}'
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return True
+
+    def raise_for_status(self):
+        if not self.raise_error:
+            return self.status_code
+
+        raise requests.HTTPError("Sample message")
+
+    def json(self):
+        return self.text
+
+def get_response(json={}):
+    return Mockresponse(200, json, False)
+
+@mock.patch("time.sleep")
+@mock.patch('requests.Session.send')
+class TestTimeOut(unittest.TestCase):
+
+    def test_timeout__accounts(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = requests.exceptions.Timeout
+
+        accounts = streams.Accounts({'x_pendo_integration_key': 'test'})
+
+        try:
+            accounts.request('accounts')
+        except requests.exceptions.Timeout:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    def test_timeout__features(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = requests.exceptions.Timeout
+
+        features = streams.Features({'x_pendo_integration_key': 'test'})
+
+        try:
+            features.request('features')
+        except requests.exceptions.Timeout:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    def test_timeout__guides(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = requests.exceptions.Timeout
+
+        guides = streams.Guides({'x_pendo_integration_key': 'test'})
+
+        try:
+            guides.request('guides')
+        except requests.exceptions.Timeout:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    def test_timeout__pages(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = requests.exceptions.Timeout
+
+        pages = streams.Pages({'x_pendo_integration_key': 'test'})
+
+        try:
+            pages.request('pages')
+        except requests.exceptions.Timeout:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    def test_timeout__feature_events(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = requests.exceptions.Timeout
+
+        feature_events = streams.FeatureEvents({'x_pendo_integration_key': 'test'})
+
+        try:
+            feature_events.request('feature_events')
+        except requests.exceptions.Timeout:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    def test_timeout__page_events(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = requests.exceptions.Timeout
+
+        page_events = streams.PageEvents({'x_pendo_integration_key': 'test'})
+
+        try:
+            page_events.request('page_events')
+        except requests.exceptions.Timeout:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    def test_timeout__guide_events(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = requests.exceptions.Timeout
+
+        guide_events = streams.GuideEvents({'x_pendo_integration_key': 'test'})
+
+        try:
+            guide_events.request('guide_events')
+        except requests.exceptions.Timeout:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    def test_timeout__poll_events(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = requests.exceptions.Timeout
+
+        poll_events = streams.PollEvents({'x_pendo_integration_key': 'test'})
+
+        try:
+            poll_events.request('poll_events')
+        except requests.exceptions.Timeout:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    def test_timeout__track_types(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = requests.exceptions.Timeout
+
+        track_types = streams.TrackTypes({'x_pendo_integration_key': 'test'})
+
+        try:
+            track_types.request('track_types')
+        except requests.exceptions.Timeout:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    def test_timeout__track_events(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = requests.exceptions.Timeout
+
+        track_events = streams.TrackEvents({'x_pendo_integration_key': 'test'})
+
+        try:
+            track_events.request('track_events')
+        except requests.exceptions.Timeout:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    def test_timeout__metadata_accounts(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = requests.exceptions.Timeout
+
+        metadata_accounts = streams.MetadataAccounts({'x_pendo_integration_key': 'test'})
+
+        try:
+            metadata_accounts.request('metadata_accounts')
+        except requests.exceptions.Timeout:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    
+    def test_timeout__metadata_visitors(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = requests.exceptions.Timeout
+
+        metadata_visitors = streams.MetadataVisitors({'x_pendo_integration_key': 'test'})
+
+        try:
+            metadata_visitors.request('metadata_visitors')
+        except requests.exceptions.Timeout:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    def test_timeout__metadata_visitor_history(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = requests.exceptions.Timeout
+
+        visitor_history = streams.VisitorHistory({'x_pendo_integration_key': 'test'})
+
+        try:
+            visitor_history.request('visitor_history', visitorId=1)
+        except requests.exceptions.Timeout:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    def test_timeout__visitors(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = requests.exceptions.Timeout
+
+        visitors = streams.Visitors({'x_pendo_integration_key': 'test'})
+
+        try:
+            visitors.request('visitors')
+        except requests.exceptions.Timeout:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    def test_timeout__events(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = requests.exceptions.Timeout
+
+        events = streams.Events({'x_pendo_integration_key': 'test'})
+
+        try:
+            events.request('events')
+        except requests.exceptions.Timeout:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+@mock.patch("time.sleep")
+@mock.patch('requests.Session.send')
+class TestConnectionResetError(unittest.TestCase):
+
+    def test_connection_reset_error__accounts(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = socket.error(104, 'Connection reset by peer')
+
+        accounts = streams.Accounts({'x_pendo_integration_key': 'test'})
+
+        try:
+            accounts.request('accounts')
+        except ConnectionResetError:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    def test_connection_reset_error__features(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = socket.error(104, 'Connection reset by peer')
+
+        features = streams.Features({'x_pendo_integration_key': 'test'})
+
+        try:
+            features.request('features')
+        except ConnectionResetError:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    def test_connection_reset_error__guides(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = socket.error(104, 'Connection reset by peer')
+
+        guides = streams.Guides({'x_pendo_integration_key': 'test'})
+
+        try:
+            guides.request('guides')
+        except ConnectionResetError:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    def test_connection_reset_error__pages(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = socket.error(104, 'Connection reset by peer')
+
+        pages = streams.Pages({'x_pendo_integration_key': 'test'})
+
+        try:
+            pages.request('pages')
+        except ConnectionResetError:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    def test_connection_reset_error__feature_events(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = socket.error(104, 'Connection reset by peer')
+
+        feature_events = streams.FeatureEvents({'x_pendo_integration_key': 'test'})
+
+        try:
+            feature_events.request('feature_events')
+        except ConnectionResetError:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    def test_connection_reset_error__page_events(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = socket.error(104, 'Connection reset by peer')
+
+        page_events = streams.PageEvents({'x_pendo_integration_key': 'test'})
+
+        try:
+            page_events.request('page_events')
+        except ConnectionResetError:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    def test_connection_reset_error__guide_events(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = socket.error(104, 'Connection reset by peer')
+
+        guide_events = streams.GuideEvents({'x_pendo_integration_key': 'test'})
+
+        try:
+            guide_events.request('guide_events')
+        except ConnectionResetError:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    def test_connection_reset_error__poll_events(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = socket.error(104, 'Connection reset by peer')
+
+        poll_events = streams.PollEvents({'x_pendo_integration_key': 'test'})
+
+        try:
+            poll_events.request('poll_events')
+        except ConnectionResetError:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    def test_connection_reset_error__track_types(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = socket.error(104, 'Connection reset by peer')
+
+        track_types = streams.TrackTypes({'x_pendo_integration_key': 'test'})
+
+        try:
+            track_types.request('track_types')
+        except ConnectionResetError:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    def test_connection_reset_error__track_events(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = socket.error(104, 'Connection reset by peer')
+
+        track_events = streams.TrackEvents({'x_pendo_integration_key': 'test'})
+
+        try:
+            track_events.request('track_events')
+        except ConnectionResetError:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    def test_connection_reset_error__metadata_accounts(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = socket.error(104, 'Connection reset by peer')
+
+        metadata_accounts = streams.MetadataAccounts({'x_pendo_integration_key': 'test'})
+
+        try:
+            metadata_accounts.request('metadata_accounts')
+        except ConnectionResetError:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    
+    def test_connection_reset_error__metadata_visitors(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = socket.error(104, 'Connection reset by peer')
+
+        metadata_visitors = streams.MetadataVisitors({'x_pendo_integration_key': 'test'})
+
+        try:
+            metadata_visitors.request('metadata_visitors')
+        except ConnectionResetError:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+
+    def test_connection_reset_error__metadata_visitor_history(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = socket.error(104, 'Connection reset by peer')
+
+        visitor_history = streams.VisitorHistory({'x_pendo_integration_key': 'test'})
+
+        try:
+            visitor_history.request('visitor_history', visitorId=1)
+        except ConnectionResetError:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    def test_connection_reset_error__visitors(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = socket.error(104, 'Connection reset by peer')
+
+        visitors = streams.Visitors({'x_pendo_integration_key': 'test'})
+
+        try:
+            visitors.request('visitors')
+        except ConnectionResetError:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    def test_connection_reset_error__events(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = socket.error(104, 'Connection reset by peer')
+
+        events = streams.Events({'x_pendo_integration_key': 'test'})
+
+        try:
+            events.request('events')
+        except ConnectionResetError:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+@mock.patch("time.sleep")
+@mock.patch('requests.Session.send')
+class TestProtocolError(unittest.TestCase):
+
+    def test_protocol_error__accounts(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = ProtocolError("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
+
+        accounts = streams.Accounts({'x_pendo_integration_key': 'test'})
+
+        try:
+            accounts.request('accounts')
+        except ProtocolError:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    def test_protocol_error__features(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = ProtocolError("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
+
+        features = streams.Features({'x_pendo_integration_key': 'test'})
+
+        try:
+            features.request('features')
+        except ProtocolError:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    def test_protocol_error__guides(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = ProtocolError("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
+
+        guides = streams.Guides({'x_pendo_integration_key': 'test'})
+
+        try:
+            guides.request('guides')
+        except ProtocolError:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    def test_protocol_error__pages(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = ProtocolError("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
+
+        pages = streams.Pages({'x_pendo_integration_key': 'test'})
+
+        try:
+            pages.request('pages')
+        except ProtocolError:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    def test_protocol_error__feature_events(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = ProtocolError("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
+
+        feature_events = streams.FeatureEvents({'x_pendo_integration_key': 'test'})
+
+        try:
+            feature_events.request('feature_events')
+        except ProtocolError:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    def test_protocol_error__page_events(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = ProtocolError("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
+
+        page_events = streams.PageEvents({'x_pendo_integration_key': 'test'})
+
+        try:
+            page_events.request('page_events')
+        except ProtocolError:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    def test_protocol_error__guide_events(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = ProtocolError("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
+
+        guide_events = streams.GuideEvents({'x_pendo_integration_key': 'test'})
+
+        try:
+            guide_events.request('guide_events')
+        except ProtocolError:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    def test_protocol_error__poll_events(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = ProtocolError("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
+
+        poll_events = streams.PollEvents({'x_pendo_integration_key': 'test'})
+
+        try:
+            poll_events.request('poll_events')
+        except ProtocolError:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    def test_protocol_error__track_types(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = ProtocolError("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
+
+        track_types = streams.TrackTypes({'x_pendo_integration_key': 'test'})
+
+        try:
+            track_types.request('track_types')
+        except ProtocolError:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    def test_protocol_error__track_events(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = ProtocolError("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
+
+        track_events = streams.TrackEvents({'x_pendo_integration_key': 'test'})
+
+        try:
+            track_events.request('track_events')
+        except ProtocolError:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    def test_protocol_error__metadata_accounts(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = ProtocolError("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
+
+        metadata_accounts = streams.MetadataAccounts({'x_pendo_integration_key': 'test'})
+
+        try:
+            metadata_accounts.request('metadata_accounts')
+        except ProtocolError:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    
+    def test_protocol_error__metadata_visitors(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = ProtocolError("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
+
+        metadata_visitors = streams.MetadataVisitors({'x_pendo_integration_key': 'test'})
+
+        try:
+            metadata_visitors.request('metadata_visitors')
+        except ProtocolError:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+
+    def test_protocol_error__metadata_visitor_history(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = ProtocolError("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
+
+        visitor_history = streams.VisitorHistory({'x_pendo_integration_key': 'test'})
+
+        try:
+            visitor_history.request('visitor_history', visitorId=1)
+        except ProtocolError:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    def test_protocol_error__visitors(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = ProtocolError("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
+
+        visitors = streams.Visitors({'x_pendo_integration_key': 'test'})
+
+        try:
+            visitors.request('visitors')
+        except ProtocolError:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+    def test_protocol_error__events(self, mocked_send, mocked_sleep):
+        mocked_send.side_effect = ProtocolError("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
+
+        events = streams.Events({'x_pendo_integration_key': 'test'})
+
+        try:
+            events.request('events')
+        except ProtocolError:
+            pass
+
+        self.assertEquals(mocked_send.call_count, 5)
+
+@mock.patch('requests.Session.send')
+class Positive(unittest.TestCase):
+
+    def test_positive__accounts(self, mocked_send):
+        json = {"key1": "value1", "key2": "value2"}
+        mocked_send.return_value = get_response(json)
+
+        accounts = streams.Accounts({'x_pendo_integration_key': 'test'})
+
+        resp = accounts.request('accounts')
+        
+        self.assertEquals(resp, json)
+
+    def test_positive__features(self, mocked_send):
+        json = {"key1": "value1", "key2": "value2"}
+        mocked_send.return_value = get_response(json)
+
+        features = streams.Features({'x_pendo_integration_key': 'test'})
+
+        resp = features.request('features')
+        
+        self.assertEquals(resp, json)
+
+    def test_positive__guides(self, mocked_send):
+        json = {"key1": "value1", "key2": "value2"}
+        mocked_send.return_value = get_response(json)
+
+        guides = streams.Guides({'x_pendo_integration_key': 'test'})
+
+        resp = guides.request('guides')
+        
+        self.assertEquals(resp, json)
+
+    def test_positive__pages(self, mocked_send):
+        json = {"key1": "value1", "key2": "value2"}
+        mocked_send.return_value = get_response(json)
+
+        pages = streams.Pages({'x_pendo_integration_key': 'test'})
+
+        resp = pages.request('pages')
+        
+        self.assertEquals(resp, json)
+
+    def test_positive__feature_events(self, mocked_send):
+        json = {"key1": "value1", "key2": "value2"}
+        mocked_send.return_value = get_response(json)
+
+        feature_events = streams.FeatureEvents({'x_pendo_integration_key': 'test'})
+
+        resp = feature_events.request('feature_events')
+        
+        self.assertEquals(resp, json)
+
+    def test_positive__page_events(self, mocked_send):
+        json = {"key1": "value1", "key2": "value2"}
+        mocked_send.return_value = get_response(json)
+
+        page_events = streams.PageEvents({'x_pendo_integration_key': 'test'})
+
+        resp = page_events.request('page_events')
+        
+        self.assertEquals(resp, json)
+
+    def test_positive__guide_events(self, mocked_send):
+        json = {"key1": "value1", "key2": "value2"}
+        mocked_send.return_value = get_response(json)
+
+        guide_events = streams.GuideEvents({'x_pendo_integration_key': 'test'})
+
+        resp = guide_events.request('guide_events')
+        
+        self.assertEquals(resp, json)
+
+    def test_positive__poll_events(self, mocked_send):
+        json = {"key1": "value1", "key2": "value2"}
+        mocked_send.return_value = get_response(json)
+
+        poll_events = streams.PollEvents({'x_pendo_integration_key': 'test'})
+
+        resp = poll_events.request('poll_events')
+        
+        self.assertEquals(resp, json)
+
+    def test_positive__track_types(self, mocked_send):
+        json = {"key1": "value1", "key2": "value2"}
+        mocked_send.return_value = get_response(json)
+
+        track_types = streams.TrackTypes({'x_pendo_integration_key': 'test'})
+
+        resp = track_types.request('track_types')
+        
+        self.assertEquals(resp, json)
+
+    def test_positive__track_events(self, mocked_send):
+        json = {"key1": "value1", "key2": "value2"}
+        mocked_send.return_value = get_response(json)
+
+        track_events = streams.TrackEvents({'x_pendo_integration_key': 'test'})
+
+        resp = track_events.request('track_events')
+        
+        self.assertEquals(resp, json)
+
+    def test_positive__metadata_accounts(self, mocked_send):
+        json = {"key1": "value1", "key2": "value2"}
+        mocked_send.return_value = get_response(json)
+
+        metadata_accounts = streams.MetadataAccounts({'x_pendo_integration_key': 'test'})
+
+        resp = metadata_accounts.request('metadata_accounts')
+        
+        self.assertEquals(resp, json)
+
+    
+    def test_positive__metadata_visitors(self, mocked_send):
+        json = {"key1": "value1", "key2": "value2"}
+        mocked_send.return_value = get_response(json)
+
+        metadata_visitors = streams.MetadataVisitors({'x_pendo_integration_key': 'test'})
+
+        resp = metadata_visitors.request('metadata_visitors')
+        
+        self.assertEquals(resp, json)
+
+
+    def test_positive__metadata_visitor_history(self, mocked_send):
+        json = {"key1": "value1", "key2": "value2"}
+        mocked_send.return_value = get_response(json)
+
+        visitor_history = streams.VisitorHistory({'x_pendo_integration_key': 'test'})
+
+        resp = visitor_history.request('visitor_history', visitorId=1)
+        
+        self.assertEquals(resp, json)
+
+    def test_positive__visitors(self, mocked_send):
+        json = {"key1": "value1", "key2": "value2"}
+        mocked_send.return_value = get_response(json)
+
+        visitors = streams.Visitors({'x_pendo_integration_key': 'test'})
+
+        resp = visitors.request('visitors')
+        
+        self.assertEquals(resp, [json])
+
+    def test_positive__events(self, mocked_send):
+        json = {"key1": "value1", "key2": "value2"}
+        mocked_send.return_value = get_response(json)
+
+        events = streams.Events({'x_pendo_integration_key': 'test'})
+
+        resp = events.request('events')
+        
+        self.assertEquals(resp, [json])

--- a/tests/unittests/test_timeout.py
+++ b/tests/unittests/test_timeout.py
@@ -1,0 +1,81 @@
+import unittest
+import requests
+from unittest import mock
+import tap_pendo.streams as streams
+
+class Mockresponse:
+    def __init__(self, status_code, json, raise_error, headers=None):
+        self.status_code = status_code
+        self.raise_error = raise_error
+        self.text = json
+        self.headers = headers
+        self.reason = "test"
+        self.raw = '{"results": [{"key1": "value1", "key2": "value2"}]}'
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return True
+
+    def raise_for_status(self):
+        if not self.raise_error:
+            return self.status_code
+
+        raise requests.HTTPError("Sample message")
+
+    def json(self):
+        return self.text
+
+def get_response(json={}):
+    return Mockresponse(200, json, False)
+
+@mock.patch("time.sleep")
+@mock.patch('requests.Session.send')
+class TestTimeOutValue(unittest.TestCase):
+
+    def test_timeout_value_in_config(self, mocked_send, mocked_sleep):
+        """
+            Verify if the request was called with param passed in the config file
+        """
+        json = {"key1": "value1", "key2": "value2"}
+        mocked_send.return_value = get_response(json)
+
+        # pass 'request_timeout' param in the config
+        stream = streams.Stream({'x_pendo_integration_key': 'test', 'request_timeout': 100})
+
+        stream.send_request_get_results('test_req')
+
+        # verify if the request was called with the desired timeout
+        mocked_send.assert_called_with('test_req', timeout=100)
+
+    def test_timeout_value_not_in_config(self, mocked_send, mocked_sleep):
+        """
+            Verify if the request was called with default timeout value
+            if the timeout param is not passed in the config file
+        """
+        json = {"key1": "value1", "key2": "value2"}
+        mocked_send.return_value = get_response(json)
+
+        # not pass 'request_timeout' param in the config
+        stream = streams.Stream({'x_pendo_integration_key': 'test'})
+
+        stream.send_request_get_results('test_req')
+
+        # verify if the request was called with default timeout
+        mocked_send.assert_called_with('test_req', timeout=300)
+
+    def test_timeout_float(self, mocked_send, mocked_sleep):
+        """
+            Verify if the request was called with decimal param passed in the config file
+        """
+        json = {"key1": "value1", "key2": "value2"}
+        mocked_send.return_value = get_response(json)
+
+        # pass decimal value of 'request_timeout' in the config
+        stream = streams.Stream({'x_pendo_integration_key': 'test', 'request_timeout': 100.002})
+
+        stream.send_request_get_results('test_req')
+
+        # verify if the request was called with passed timeout param
+        mocked_send.assert_called_with('test_req', timeout=100.002)

--- a/tests/unittests/test_timeout.py
+++ b/tests/unittests/test_timeout.py
@@ -34,7 +34,7 @@ def get_response(json={}):
 @mock.patch('requests.Session.send')
 class TestTimeOutValue(unittest.TestCase):
 
-    def test_timeout_value_in_config(self, mocked_send, mocked_sleep):
+    def test_timeout_value_in_config__Stream(self, mocked_send, mocked_sleep):
         """
             Verify if the request was called with param passed in the config file
         """
@@ -49,7 +49,7 @@ class TestTimeOutValue(unittest.TestCase):
         # verify if the request was called with the desired timeout
         mocked_send.assert_called_with('test_req', timeout=100)
 
-    def test_timeout_value_not_in_config(self, mocked_send, mocked_sleep):
+    def test_timeout_value_not_in_config__Stream(self, mocked_send, mocked_sleep):
         """
             Verify if the request was called with default timeout value
             if the timeout param is not passed in the config file
@@ -65,7 +65,7 @@ class TestTimeOutValue(unittest.TestCase):
         # verify if the request was called with default timeout
         mocked_send.assert_called_with('test_req', timeout=300)
 
-    def test_timeout_float(self, mocked_send, mocked_sleep):
+    def test_timeout_float__Stream(self, mocked_send, mocked_sleep):
         """
             Verify if the request was called with decimal param passed in the config file
         """
@@ -79,3 +79,49 @@ class TestTimeOutValue(unittest.TestCase):
 
         # verify if the request was called with passed timeout param
         mocked_send.assert_called_with('test_req', timeout=100.002)
+
+    def test_timeout_value_in_config__LazyAggregation(self, mocked_send, mocked_sleep):
+        """
+            Verify if the request was called with param passed in the config file
+        """
+        json = {"key1": "value1", "key2": "value2"}
+        mocked_send.return_value = get_response(json)
+
+        # pass 'request_timeout' param in the config
+        stream = streams.LazyAggregationStream({'x_pendo_integration_key': 'test', 'request_timeout': 100})
+
+        stream.send_request_get_results('test_req')
+
+        # verify if the request was called with the desired timeout
+        mocked_send.assert_called_with('test_req', stream=True, timeout=100)
+
+    def test_timeout_value_not_in_config__LazyAggregation(self, mocked_send, mocked_sleep):
+        """
+            Verify if the request was called with default timeout value
+            if the timeout param is not passed in the config file
+        """
+        json = {"key1": "value1", "key2": "value2"}
+        mocked_send.return_value = get_response(json)
+
+        # not pass 'request_timeout' param in the config
+        stream = streams.LazyAggregationStream({'x_pendo_integration_key': 'test'})
+
+        stream.send_request_get_results('test_req')
+
+        # verify if the request was called with default timeout
+        mocked_send.assert_called_with('test_req', stream=True, timeout=300)
+
+    def test_timeout_float__LazyAggregation(self, mocked_send, mocked_sleep):
+        """
+            Verify if the request was called with decimal param passed in the config file
+        """
+        json = {"key1": "value1", "key2": "value2"}
+        mocked_send.return_value = get_response(json)
+
+        # pass decimal value of 'request_timeout' in the config
+        stream = streams.LazyAggregationStream({'x_pendo_integration_key': 'test', 'request_timeout': 100.002})
+
+        stream.send_request_get_results('test_req')
+
+        # verify if the request was called with passed timeout param
+        mocked_send.assert_called_with('test_req', stream=True, timeout=100.002)

--- a/tests/unittests/test_timeout_value.py
+++ b/tests/unittests/test_timeout_value.py
@@ -81,6 +81,22 @@ class TestTimeOutValue(unittest.TestCase):
         # verify if the request was called with passed timeout param
         mocked_send.assert_called_with('test_req', timeout=100.0)
 
+    def test_timeout_empty__Stream(self, mocked_send, mocked_sleep):
+        """
+            Verify if the request was called with default timeout
+            as param passed in the config file is empty string
+        """
+        json = {"key1": "value1", "key2": "value2"}
+        mocked_send.return_value = get_response(json)
+
+        # pass empty string value of 'request_timeout' in the config
+        stream = streams.Stream({'x_pendo_integration_key': 'test', 'request_timeout': ""})
+
+        stream.send_request_get_results('test_req')
+
+        # verify if the request was called with passed timeout param
+        mocked_send.assert_called_with('test_req', timeout=300.0)
+
     def test_timeout_value_in_config__LazyAggregation(self, mocked_send, mocked_sleep):
         """
             Verify if the request was called with timeout value param passed in the config file
@@ -127,3 +143,19 @@ class TestTimeOutValue(unittest.TestCase):
 
         # verify if the request was called with passed timeout param
         mocked_send.assert_called_with('test_req', stream=True, timeout=100.0)
+
+    def test_timeout_empty__LazyAggregation(self, mocked_send, mocked_sleep):
+        """
+            Verify if the request was called with default timeout
+            as param passed in the config file is empty string
+        """
+        json = {"key1": "value1", "key2": "value2"}
+        mocked_send.return_value = get_response(json)
+
+        # pass string value of 'request_timeout' in the config
+        stream = streams.LazyAggregationStream({'x_pendo_integration_key': 'test', 'request_timeout': ""})
+
+        stream.send_request_get_results('test_req')
+
+        # verify if the request was called with passed timeout param
+        mocked_send.assert_called_with('test_req', stream=True, timeout=300.0)

--- a/tests/unittests/test_timeout_value.py
+++ b/tests/unittests/test_timeout_value.py
@@ -97,6 +97,38 @@ class TestTimeOutValue(unittest.TestCase):
         # verify if the request was called with passed timeout param
         mocked_send.assert_called_with('test_req', timeout=300.0)
 
+    def test_timeout_0__Stream(self, mocked_send, mocked_sleep):
+        """
+            Verify if the request was called with default timeout
+            as param passed in the config file is 0
+        """
+        json = {"key1": "value1", "key2": "value2"}
+        mocked_send.return_value = get_response(json)
+
+        # pass empty string value of 'request_timeout' in the config
+        stream = streams.Stream({'x_pendo_integration_key': 'test', 'request_timeout': 0.0})
+
+        stream.send_request_get_results('test_req')
+
+        # verify if the request was called with passed timeout param
+        mocked_send.assert_called_with('test_req', timeout=300.0)
+
+    def test_timeout_string_0__Stream(self, mocked_send, mocked_sleep):
+        """
+            Verify if the request was called with default timeout
+            as param passed in the config file is string 0
+        """
+        json = {"key1": "value1", "key2": "value2"}
+        mocked_send.return_value = get_response(json)
+
+        # pass empty string value of 'request_timeout' in the config
+        stream = streams.Stream({'x_pendo_integration_key': 'test', 'request_timeout': "0.0"})
+
+        stream.send_request_get_results('test_req')
+
+        # verify if the request was called with passed timeout param
+        mocked_send.assert_called_with('test_req', timeout=300.0)
+
     def test_timeout_value_in_config__LazyAggregation(self, mocked_send, mocked_sleep):
         """
             Verify if the request was called with timeout value param passed in the config file
@@ -154,6 +186,38 @@ class TestTimeOutValue(unittest.TestCase):
 
         # pass string value of 'request_timeout' in the config
         stream = streams.LazyAggregationStream({'x_pendo_integration_key': 'test', 'request_timeout': ""})
+
+        stream.send_request_get_results('test_req')
+
+        # verify if the request was called with passed timeout param
+        mocked_send.assert_called_with('test_req', stream=True, timeout=300.0)
+
+    def test_timeout_0__LazyAggregation(self, mocked_send, mocked_sleep):
+        """
+            Verify if the request was called with default timeout
+            as param passed in the config file is 0
+        """
+        json = {"key1": "value1", "key2": "value2"}
+        mocked_send.return_value = get_response(json)
+
+        # pass string value of 'request_timeout' in the config
+        stream = streams.LazyAggregationStream({'x_pendo_integration_key': 'test', 'request_timeout': 0.0})
+
+        stream.send_request_get_results('test_req')
+
+        # verify if the request was called with passed timeout param
+        mocked_send.assert_called_with('test_req', stream=True, timeout=300.0)
+
+    def test_timeout_string_0__LazyAggregation(self, mocked_send, mocked_sleep):
+        """
+            Verify if the request was called with default timeout
+            as param passed in the config file is string 0
+        """
+        json = {"key1": "value1", "key2": "value2"}
+        mocked_send.return_value = get_response(json)
+
+        # pass string value of 'request_timeout' in the config
+        stream = streams.LazyAggregationStream({'x_pendo_integration_key': 'test', 'request_timeout': "0.0"})
 
         stream.send_request_get_results('test_req')
 

--- a/tests/unittests/test_timeout_value.py
+++ b/tests/unittests/test_timeout_value.py
@@ -36,7 +36,7 @@ class TestTimeOutValue(unittest.TestCase):
 
     def test_timeout_value_in_config__Stream(self, mocked_send, mocked_sleep):
         """
-            Verify if the request was called with param passed in the config file
+            Verify if the request was called with timeout value param passed in the config file
         """
         json = {"key1": "value1", "key2": "value2"}
         mocked_send.return_value = get_response(json)
@@ -47,12 +47,12 @@ class TestTimeOutValue(unittest.TestCase):
         stream.send_request_get_results('test_req')
 
         # verify if the request was called with the desired timeout
-        mocked_send.assert_called_with('test_req', timeout=100)
+        mocked_send.assert_called_with('test_req', timeout=100.0)
 
     def test_timeout_value_not_in_config__Stream(self, mocked_send, mocked_sleep):
         """
             Verify if the request was called with default timeout value
-            if the timeout param is not passed in the config file
+            as the timeout param is not passed in the config file
         """
         json = {"key1": "value1", "key2": "value2"}
         mocked_send.return_value = get_response(json)
@@ -63,26 +63,27 @@ class TestTimeOutValue(unittest.TestCase):
         stream.send_request_get_results('test_req')
 
         # verify if the request was called with default timeout
-        mocked_send.assert_called_with('test_req', timeout=300)
+        mocked_send.assert_called_with('test_req', timeout=300.0)
 
-    def test_timeout_float__Stream(self, mocked_send, mocked_sleep):
+    def test_timeout_string__Stream(self, mocked_send, mocked_sleep):
         """
-            Verify if the request was called with decimal param passed in the config file
+            Verify if the request was called with integer timeout
+            as param passed in the config file is in string
         """
         json = {"key1": "value1", "key2": "value2"}
         mocked_send.return_value = get_response(json)
 
-        # pass decimal value of 'request_timeout' in the config
-        stream = streams.Stream({'x_pendo_integration_key': 'test', 'request_timeout': 100.002})
+        # pass string value of 'request_timeout' in the config
+        stream = streams.Stream({'x_pendo_integration_key': 'test', 'request_timeout': "100"})
 
         stream.send_request_get_results('test_req')
 
         # verify if the request was called with passed timeout param
-        mocked_send.assert_called_with('test_req', timeout=100.002)
+        mocked_send.assert_called_with('test_req', timeout=100.0)
 
     def test_timeout_value_in_config__LazyAggregation(self, mocked_send, mocked_sleep):
         """
-            Verify if the request was called with param passed in the config file
+            Verify if the request was called with timeout value param passed in the config file
         """
         json = {"key1": "value1", "key2": "value2"}
         mocked_send.return_value = get_response(json)
@@ -93,12 +94,12 @@ class TestTimeOutValue(unittest.TestCase):
         stream.send_request_get_results('test_req')
 
         # verify if the request was called with the desired timeout
-        mocked_send.assert_called_with('test_req', stream=True, timeout=100)
+        mocked_send.assert_called_with('test_req', stream=True, timeout=100.0)
 
     def test_timeout_value_not_in_config__LazyAggregation(self, mocked_send, mocked_sleep):
         """
             Verify if the request was called with default timeout value
-            if the timeout param is not passed in the config file
+            as the timeout param is not passed in the config file
         """
         json = {"key1": "value1", "key2": "value2"}
         mocked_send.return_value = get_response(json)
@@ -109,19 +110,20 @@ class TestTimeOutValue(unittest.TestCase):
         stream.send_request_get_results('test_req')
 
         # verify if the request was called with default timeout
-        mocked_send.assert_called_with('test_req', stream=True, timeout=300)
+        mocked_send.assert_called_with('test_req', stream=True, timeout=300.0)
 
-    def test_timeout_float__LazyAggregation(self, mocked_send, mocked_sleep):
+    def test_timeout_string__LazyAggregation(self, mocked_send, mocked_sleep):
         """
-            Verify if the request was called with decimal param passed in the config file
+            Verify if the request was called with integer timeout
+            as param passed in the config file is in string
         """
         json = {"key1": "value1", "key2": "value2"}
         mocked_send.return_value = get_response(json)
 
-        # pass decimal value of 'request_timeout' in the config
-        stream = streams.LazyAggregationStream({'x_pendo_integration_key': 'test', 'request_timeout': 100.002})
+        # pass string value of 'request_timeout' in the config
+        stream = streams.LazyAggregationStream({'x_pendo_integration_key': 'test', 'request_timeout': "100"})
 
         stream.send_request_get_results('test_req')
 
         # verify if the request was called with passed timeout param
-        mocked_send.assert_called_with('test_req', stream=True, timeout=100.002)
+        mocked_send.assert_called_with('test_req', stream=True, timeout=100.0)


### PR DESCRIPTION
# Description of change
TDL-14913: Add retry logic to requests
- Added backoff for ConnectionResetError and ProtocolError

TDL-14884: Add timeouts and retries to requests
- Added timeout to requests

NOTE: Backoff for Timeout error is already included in `requests.exceptions.RequestException` as it is the parent class of 'Timeout' error.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
