### PR TITLE
TDL-15671: For FULL_TABLE stream, the record count shown by the logger message is incorrect

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
             python3 -mvenv /usr/local/share/virtualenvs/tap-pendo
             source /usr/local/share/virtualenvs/tap-pendo/bin/activate
             pip install -U pip setuptools
-            pip install .[dev]
+            pip install .[test]
       - run:
           name: 'JSON Validator'
           command: |
@@ -23,6 +23,11 @@ jobs:
             source /usr/local/share/virtualenvs/tap-pendo/bin/activate
             # TODO: Adjust the pylint disables
             pylint tap_pendo --disable 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,bad-whitespace,missing-class-docstring'
+      - run:
+          name: 'Unit Tests'
+          command: |
+            source /usr/local/share/virtualenvs/tap-pendo/bin/activate
+            nosetests tests/unittests
       - add_ssh_keys
       - run:
           name: 'Integration Tests'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,13 @@ jobs:
           name: 'Unit Tests'
           command: |
             source /usr/local/share/virtualenvs/tap-pendo/bin/activate
-            nosetests tests/unittests
+            pip install coverage
+            nosetests --with-coverage --cover-erase --cover-package=tap_pendo --cover-html-dir=htmlcov tests/unittests
+            coverage html
+      - store_test_results:
+          path: test_output/report.xml
+      - store_artifacts:
+          path: htmlcov
       - add_ssh_keys
       - run:
           name: 'Integration Tests'

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,12 @@ setup(
         'ijson==3.1.4',
     ],
     extras_require={
-        'dev': [
-            'ipdb==0.11',
+        'test': [
             'pylint==2.5.3',
+            'nose'
+        ],
+        'dev': [
+            'ipdb==0.11'
         ]
     },
     entry_points="""

--- a/tap_pendo/sync.py
+++ b/tap_pendo/sync.py
@@ -82,4 +82,4 @@ def sync_full_table(state, instance):
 
             singer.write_record(stream.tap_stream_id, transformed_record)
             counter.increment()
-    return counter.value
+        return counter.value

--- a/tap_pendo/sync.py
+++ b/tap_pendo/sync.py
@@ -82,4 +82,5 @@ def sync_full_table(state, instance):
 
             singer.write_record(stream.tap_stream_id, transformed_record)
             counter.increment()
+        # return the count of records synced
         return counter.value

--- a/tests/unittests/test_full_table_sync_record_count.py
+++ b/tests/unittests/test_full_table_sync_record_count.py
@@ -1,0 +1,51 @@
+import unittest
+from unittest import mock
+from tap_pendo.sync import sync_full_table
+import tap_pendo.streams as streams
+
+class Schema:
+    schema = None
+
+    def __init__(self, schema):
+        self.schema = schema
+
+    def to_dict(self):
+        return self.schema
+
+class MockStream:
+    tap_stream_id = None
+    schema = None
+    metadata = {}
+
+    def __init__(self, id):
+        self.tap_stream_id = id
+        self.schema = Schema({})
+
+class TestFullTableSyncRecordCount(unittest.TestCase):
+
+    @mock.patch("tap_pendo.streams.Stream.sync")
+    @mock.patch("singer.write_record")
+    def test_valid_value_for_replication_key(self, mocked_write, mocked_sync):
+        """
+            Verify that 'counter.value' ie. number of records returned from
+            'sync_full_table' is same as the number of records
+        """
+
+        mock_config = mock_state = {}
+
+        # create dummy records
+        mock_records = [{"id":1, "name": "test1"},
+                        {"id":2, "name": "test2"},
+                        {"id":2, "name": "test3"}]
+
+        # 'sync' returns Stream class and records
+        mocked_sync.return_value = MockStream('test'), mock_records
+
+        stream_instance = streams.Stream(mock_config)
+        stream_instance.stream = MockStream('test')
+
+        # call the full table sync function
+        counter = sync_full_table(mock_state, stream_instance)
+
+        # verify that the counter is same as the number of dummy records
+        self.assertEqual(counter, len(mock_records))


### PR DESCRIPTION
# Description of change
TDL-15671: For FULL_TABLE stream, the record count shown by the logger message is incorrect

- Updated the code and shifted `counter.value` inside the `with` statement.

# Manual QA steps
 - Select `metadata_accouts` and `metadata_visitors` stream and run sync mode.
- The count of records should be the same as the number of records for that stream.

 
# Risks
 - 
 
# Rollback steps
 - revert this branch
