### PR TITLE
TDL-16155: Fix out of memory error

### DIFF
--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -416,18 +416,26 @@ class LazyAggregationStream(Stream):
         # If value is 0,"0", "" or None then it will set default to default to 300.0 seconds if not passed in config.
         config_request_timeout = self.config.get('request_timeout')
         request_timeout = config_request_timeout and float(config_request_timeout) or REQUEST_TIMEOUT # pylint: disable=consider-using-ternary
-        with session.send(req, stream=True, timeout=request_timeout) as resp:
-            if 'Too Many Requests' in resp.reason:
-                retry_after = 30
-                LOGGER.info("Rate limit reached. Sleeping for %s seconds",
-                            retry_after)
-                time.sleep(retry_after)
-                raise Server42xRateLimitError(resp.reason)
+        resp = session.send(req, stream=True, timeout=request_timeout)
 
-            resp.raise_for_status() # Check for requests status and raise exception in failure
+        if 'Too Many Requests' in resp.reason:
+            retry_after = 30
+            LOGGER.info("Rate limit reached. Sleeping for %s seconds",
+                        retry_after)
+            time.sleep(retry_after)
+            raise Server42xRateLimitError(resp.reason)
 
-            for item in ijson.items(resp.raw, 'results.item'):
-                yield humps.decamelize(item)
+        resp.raise_for_status() # Check for requests status and raise exception in failure
+
+        # Separated yielding of records into a new function and called that here 
+        # so that any exception raised from the session.send can be thrown from here and
+        # handled properly using backoff on request function. 
+        return self.send_records(resp)
+
+    def send_records(self, resp):
+        # Yielding records from results
+        for item in ijson.items(resp.raw, 'results.item'):
+            yield humps.decamelize(item)
 
     def sync(self, state, start_date=None, key_id=None):
         stream_response = self.request(self.name, json=self.get_body()) or []
@@ -442,7 +450,8 @@ class LazyAggregationStream(Stream):
         if stream_response and sub_stream and sub_stream.is_selected():
             self.sync_substream(state, self, sub_stream, stream_response)
 
-            # Get parent data again as stream_response is generator ehich was flush out durinf sync_substream
+            # Get parent data again as stream_response returned from request() is a generator
+            # which flush out during sync_substream call above
             stream_response = self.request(self.name, json=self.get_body()) or []
 
         return (self.stream, stream_response)

--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -416,6 +416,8 @@ class LazyAggregationStream(Stream):
         # If value is 0,"0", "" or None then it will set default to default to 300.0 seconds if not passed in config.
         config_request_timeout = self.config.get('request_timeout')
         request_timeout = config_request_timeout and float(config_request_timeout) or REQUEST_TIMEOUT # pylint: disable=consider-using-ternary
+        # Send request for stream data directly(without 'with' statement) so that
+        # exception handling and yielding can be utilized properly below
         resp = session.send(req, stream=True, timeout=request_timeout)
 
         if 'Too Many Requests' in resp.reason:

--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -427,9 +427,9 @@ class LazyAggregationStream(Stream):
 
         resp.raise_for_status() # Check for requests status and raise exception in failure
 
-        # Separated yielding of records into a new function and called that here 
+        # Separated yielding of records into a new function and called that here
         # so that any exception raised from the session.send can be thrown from here and
-        # handled properly using backoff on request function. 
+        # handled properly using backoff on request function.
         return self.send_records(resp)
 
     def send_records(self, resp):

--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -438,6 +438,7 @@ class LazyAggregationStream(Stream):
         # Yielding records from results
         for item in ijson.items(resp.raw, 'results.item'):
             yield humps.decamelize(item)
+        resp.close()
 
     def sync(self, state, start_date=None, key_id=None):
         stream_response = self.request(self.name, json=self.get_body()) or []

--- a/tests/unittests/test_backoff.py
+++ b/tests/unittests/test_backoff.py
@@ -902,7 +902,7 @@ class Positive(unittest.TestCase):
         resp = visitors.request('visitors')
         
         # verify if the desired data was returned from the request
-        self.assertEquals(resp, [json])
+        self.assertEquals(list(resp), [json])
 
     def test_positive__events(self, mocked_send):
         json = {"key1": "value1", "key2": "value2"}
@@ -915,4 +915,4 @@ class Positive(unittest.TestCase):
         resp = events.request('events')
         
         # verify if the desired data was returned from the request
-        self.assertEquals(resp, [json])
+        self.assertEquals(list(resp), [json])

--- a/tests/unittests/test_backoff.py
+++ b/tests/unittests/test_backoff.py
@@ -29,6 +29,9 @@ class Mockresponse:
     def json(self):
         return self.text
 
+    def close(self):
+        return True
+
 def get_response(json={}):
     return Mockresponse(200, json, False)
 

--- a/tests/unittests/test_lazy_aggregation_sync.py
+++ b/tests/unittests/test_lazy_aggregation_sync.py
@@ -23,6 +23,9 @@ class Mockresponse:
     def __exit__(self, exc_type, exc_value, tb):
         return True
 
+    def close(self):
+        return True
+
 # Mocking sync of substream
 def mocked_substream(state, parent, sub_stream, parent_response):
     for record in parent_response:

--- a/tests/unittests/test_lazy_aggregation_sync.py
+++ b/tests/unittests/test_lazy_aggregation_sync.py
@@ -51,7 +51,7 @@ class TestLazyAggregationSync(unittest.TestCase):
         lazzy_aggr = Visitors(config)
         stream, stream_response = lazzy_aggr.sync({})
 
-        self.assertEqual(stream_response, expected_data) # parent stream get all expected data
+        self.assertEqual(list(stream_response), expected_data) # parent stream get all expected data
         self.assertEqual(mocked_substream.call_count, 1)
 
     @mock.patch("requests.Session.send")
@@ -72,5 +72,5 @@ class TestLazyAggregationSync(unittest.TestCase):
         lazzy_aggr = Visitors(config)
         stream, stream_response = lazzy_aggr.sync({})
 
-        self.assertEqual(stream_response, expected_data)
+        self.assertEqual(list(stream_response), expected_data)
         self.assertEqual(mocked_substream.call_count, 0)


### PR DESCRIPTION
# Description of change
[TDL-16155](https://jira.talendforge.org/browse/TDL-16155) Fix out of memory error
- We had updated yielding logic with a list of records as part of [TDL-14945](https://jira.talendforge.org/browse/TDL-14945) but that looks the root cause for the out of memory error as the tap was working fine before.
- Revert back the logic of records-list with yielding as before and added one additional call for parent data(visitors) after syncing of sub_stream because the generator is flush out after sub-stream sync.
- We have added exception handling before based on the list-records approach but due to revert back we also split out the `send_request_get_results` function of `LazyAggregationStream` so that `send` request can throw an exception in that function and be handled properly.
- While doing that we encountered one error so we removed `with` statement from the `send_request_get_results` function of `LazyAggregationStream` class. (Added details in JIRA comment)

# Manual QA steps
 -  Verified that we are getting data for visitors and visitor_history when both streams are selected.
 -  Verified that all the unit tests related to exception handling are passing for  LazyAggregationStream class.
 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
