### PR TITLE
TDL-15148: Find better PK for guide_events

### DIFF
--- a/tap_pendo/schemas/guide_events.json
+++ b/tap_pendo/schemas/guide_events.json
@@ -31,6 +31,12 @@
         "guide_id": {
             "type": ["null", "string"]
         },
+        "guide_step_id": {
+            "type": ["null", "string"]
+        },
+        "url": {
+            "type": ["null", "string"]
+        },
         "latitude": {
             "type": ["null", "number"]
         },

--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -718,7 +718,7 @@ class TrackEvents(EventsBase):
 class GuideEvents(EventsBase):
     replication_method = "INCREMENTAL"
     name = "guide_events"
-    key_properties = ['visitor_id', 'account_id', 'server_name', 'remote_ip']
+    key_properties = ['guide_id', 'guide_step_id', 'visitor_id', 'type', 'account_id', 'browser_time', 'server_name', 'url']
 
     def __init__(self, config):
         super().__init__(config=config)

--- a/tests/tap_tester/base.py
+++ b/tests/tap_tester/base.py
@@ -94,7 +94,7 @@ class TestPendoBase(unittest.TestCase):
                 self.REPLICATION_KEYS: {'day'}
             },
             "guide_events": {
-                self.PRIMARY_KEYS: {"visitor_id", "account_id", "server_name", "remote_ip"},
+                self.PRIMARY_KEYS: {"guide_id", "guide_step_id", "visitor_id", "type", "account_id", "browser_time", "server_name", "url"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {'browser_time'}
             },


### PR DESCRIPTION
# Description of change
TDL-15148: Find better PK for guide_events
- Updated the Primary Key for guide events: `[guide_id, guide_step_id, visitor_id, type, account_id, browser_time, server_name, url]`

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
