### PR TITLE
TDL-15362: Find better PK for poll_events

### DIFF
--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -636,7 +636,7 @@ class Events(LazyAggregationStream):
 class PollEvents(Stream):
     replication_method = "INCREMENTAL"
     name = "poll_events"
-    key_properties = ['visitor_id', 'account_id', 'server_name', 'remote_ip']
+    key_properties = ['visitor_id', 'account_id', 'poll_id', 'browser_time']
 
     def __init__(self, config):
         super().__init__(config=config)

--- a/tests/tap_tester/base.py
+++ b/tests/tap_tester/base.py
@@ -99,7 +99,7 @@ class TestPendoBase(unittest.TestCase):
                 self.REPLICATION_KEYS: {'browser_time'}
             },
             "poll_events":{
-                self.PRIMARY_KEYS: {"visitor_id", "account_id", "server_name", "remote_ip"},
+                self.PRIMARY_KEYS: {"visitor_id", "account_id", "poll_id", "browser_time"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {'browser_time'}
             },

--- a/tests/unittests/test_poll_events_primary_key.py
+++ b/tests/unittests/test_poll_events_primary_key.py
@@ -1,0 +1,19 @@
+import unittest
+from tap_pendo.streams import PollEvents
+
+class TestPollEventsPrimaryKey(unittest.TestCase):
+
+    def test_poll_event_primary_key(self):
+        '''
+            Verify that primary keys for 'poll_events' stream
+        '''
+        # initialize config
+        config = {}
+        # expected primary key
+        expected_primary_keys = ['visitor_id', 'account_id', 'poll_id', 'browser_time']
+
+        # Initialize PollEvents object which sets primary keys
+        poll_events = PollEvents(config)
+
+        # verify the Primary Key
+        self.assertEqual(poll_events.key_properties, expected_primary_keys)


### PR DESCRIPTION
# Description of change
TDL-15362: Find better PK for poll_events
- Updated the Primary Key for poll events: `'visitor_id', 'account_id', 'poll_id', 'browser_time'`

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
