### PR TITLE
TDL-17163: Reduce requested data for pages

### DIFF
--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -517,8 +517,7 @@ class LazyAggregationStream(Stream):
         if sub_stream and sub_stream.is_selected():
             # Sub streams are using lookback so use lookback for parents also while using it for sub stream
             stream_response = self.get_records(state, bookmark_dttm - timedelta(days=self.lookback_window()))
-            if stream_response:
-                self.sync_substream(state, self, sub_stream, stream_response)
+            self.sync_substream(state, self, sub_stream, stream_response)
 
         # Collect data for stream even if it is already collected for a sub-stream above as stream_response is a generator
         # which flush out during sync_substream call above

--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -880,7 +880,6 @@ class Pages(Stream):
     replication_key = "lastUpdatedAt"
 
     def get_body(self, bookmark):
-        # bookmark = "1637901743542"
         return {
             "response": {
                 "mimeType": "application/json"

--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -106,6 +106,7 @@ class Stream():
     name = None
     replication_method = None
     replication_key = None
+    replication_key_path = None
     key_properties = KEY_PROPERTIES
     stream = None
     period = None
@@ -451,6 +452,11 @@ class Stream():
             raise TypeError("lookback_window '{}' is not numeric. Check your configuration".format(lookback_window))
         return int(lookback_window)
 
+    def build_filter(self, start, end):
+        # Create filter with start_time and end_time to pass in request body
+        # Ex. of filter: "lastUpdatedAt > 1637905603845 && lastUpdatedAt <= 1637908104974"
+        return self.replication_key_path + " > " + str(start) + " && " + self.replication_key_path + " <= " + str(end)
+
 class LazyAggregationStream(Stream):
     def send_request_get_results(self, req):
         # Set request timeout to config param `request_timeout` value.
@@ -535,9 +541,6 @@ class Accounts(Stream):
     key_properties = ["account_id"]
 
     def get_body(self, start, end):
-        # Ex. of filter: "metadata.auto.lastupdated > 1637905603845 && metadata.auto.lastupdated <= 1637908104974"
-        filter = self.replication_key_path + " > " + str(start) + " && " + self.replication_key_path + " <= " + str(end)
-
         return {
             "response": {
                 "mimeType": "application/json"
@@ -549,7 +552,7 @@ class Accounts(Stream):
                         "accounts": None
                     }
                 }, {
-                    "filter": filter
+                    "filter": self.build_filter(start, end)
                 }],
                 "requestId": "all-accounts",
                 "sort": ["accountId"]
@@ -573,11 +576,9 @@ class Features(Stream):
     name = "features"
     replication_method = "INCREMENTAL"
     replication_key = "lastUpdatedAt"
+    replication_key_path = "lastUpdatedAt"
 
     def get_body(self, start, end):
-        # Ex. of filter: "lastUpdatedAt > 1637905603845 && lastUpdatedAt <= 1637908104974"
-        filter = self.replication_key + " > " + str(start) + " && " + self.replication_key + " <= " + str(end)
-
         return {
             "response": {
                 "mimeType": "application/json"
@@ -592,7 +593,7 @@ class Features(Stream):
                 }, {
                     "sort": ["id"]
                 }, {
-                    "filter": filter
+                    "filter": self.build_filter(start, end)
                 }],
                 "requestId":
                 "all-features"
@@ -866,11 +867,9 @@ class TrackTypes(Stream):
     name = "track_types"
     replication_method = "INCREMENTAL"
     replication_key = "lastUpdatedAt"
+    replication_key_path = "lastUpdatedAt"
 
     def get_body(self, start, end):
-        # Ex. of filter: "lastUpdatedAt > 1637905603845 && lastUpdatedAt <= 1637908104974"
-        filter = self.replication_key + " > " + str(start) + " && " + self.replication_key + " <= " + str(end)
-
         return {
             "response": {
                 "mimeType": "application/json"
@@ -884,7 +883,7 @@ class TrackTypes(Stream):
                 }, {
                     "sort": ["id"]
                 }, {
-                    "filter": filter
+                    "filter": self.build_filter(start, end)
                 }],
                 "requestId": "all-track-types"
             }
@@ -895,11 +894,9 @@ class Guides(Stream):
     name = "guides"
     replication_method = "INCREMENTAL"
     replication_key = "lastUpdatedAt"
+    replication_key_path = "lastUpdatedAt"
 
     def get_body(self, start, end):
-        # Ex. of filter: "lastUpdatedAt > 1637905603845 && lastUpdatedAt <= 1637908104974"
-        filter = self.replication_key + " > " + str(start) + " && " + self.replication_key + " <= " + str(end)
-
         return {
             "response": {
                 "mimeType": "application/json"
@@ -914,7 +911,7 @@ class Guides(Stream):
                 }, {
                     "sort": ["id"]
                 }, {
-                    "filter": filter
+                    "filter": self.build_filter(start, end)
                 }],
                 "requestId":
                 "all-guides"
@@ -926,11 +923,9 @@ class Pages(Stream):
     name = "pages"
     replication_method = "INCREMENTAL"
     replication_key = "lastUpdatedAt"
+    replication_key_path = "lastUpdatedAt"
 
     def get_body(self, start, end):
-        # Ex. of filter: "lastUpdatedAt > 1637905603845 && lastUpdatedAt <= 1637908104974"
-        filter = self.replication_key + " > " + str(start) + " && " + self.replication_key + " <= " + str(end)
-
         return {
             "response": {
                 "mimeType": "application/json"
@@ -945,7 +940,7 @@ class Pages(Stream):
                 }, {
                     "sort": ["id"]
                 }, {
-                    "filter": filter
+                    "filter": self.build_filter(start, end)
                 }],
                 "requestId":
                 "all-pages"

--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -435,7 +435,7 @@ class Stream():
             start_epoch = int(start_dttm.timestamp()) * 1000
             end_epoch = int(end_dttm.timestamp()) * 1000
 
-            # Get page records between start_epoch and end_epoch 
+            # Get page records between start_epoch and end_epoch
             records = self.get_page_response(start_epoch, end_epoch)
             record = None
 

--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -388,7 +388,12 @@ class Stream():
 
 
     def sync(self, state, start_date=None, key_id=None):
-        stream_response = self.request(self.name, json=self.get_body())['results'] or []
+        # Get bookmark and convert it into epoch for filter data in request
+        bookmark_date = self.get_bookmark(state, self.name, start_date,
+                                          self.replication_key)
+        bookmark_epoch = datetime.timestamp(strptime_to_utc(bookmark_date)) * 1000
+
+        stream_response = self.request(self.name, json=self.get_body(bookmark_epoch))['results'] or []
 
         # Get and intialize sub-stream for the current stream
         if STREAMS.get(SUB_STREAMS.get(self.name)):
@@ -490,9 +495,10 @@ class Accounts(Stream):
     name = "accounts"
     replication_method = "INCREMENTAL"
     replication_key = "lastupdated"
+    replication_key_path = "metadata.auto.lastupdated"
     key_properties = ["account_id"]
 
-    def get_body(self):
+    def get_body(self, bookmark):
         return {
             "response": {
                 "mimeType": "application/json"
@@ -503,6 +509,8 @@ class Accounts(Stream):
                     "source": {
                         "accounts": None
                     }
+                }, {
+                    "filter": self.replication_key_path + " > " + str(bookmark)
                 }],
                 "requestId": "all-accounts",
                 "sort": ["accountId"]
@@ -527,7 +535,7 @@ class Features(Stream):
     replication_method = "INCREMENTAL"
     replication_key = "lastUpdatedAt"
 
-    def get_body(self):
+    def get_body(self, bookmark):
         return {
             "response": {
                 "mimeType": "application/json"
@@ -541,6 +549,8 @@ class Features(Stream):
                     }
                 }, {
                     "sort": ["id"]
+                }, {
+                    "filter": self.replication_key + " > " + str(bookmark)
                 }],
                 "requestId":
                 "all-features"
@@ -815,7 +825,7 @@ class TrackTypes(Stream):
     replication_method = "INCREMENTAL"
     replication_key = "lastUpdatedAt"
 
-    def get_body(self):
+    def get_body(self, bookmark):
         return {
             "response": {
                 "mimeType": "application/json"
@@ -828,6 +838,8 @@ class TrackTypes(Stream):
                     }
                 }, {
                     "sort": ["id"]
+                }, {
+                    "filter": self.replication_key + " > " + str(bookmark)
                 }],
                 "requestId": "all-track-types"
             }
@@ -839,7 +851,7 @@ class Guides(Stream):
     replication_method = "INCREMENTAL"
     replication_key = "lastUpdatedAt"
 
-    def get_body(self):
+    def get_body(self, bookmark):
         return {
             "response": {
                 "mimeType": "application/json"
@@ -853,6 +865,8 @@ class Guides(Stream):
                     }
                 }, {
                     "sort": ["id"]
+                }, {
+                    "filter": self.replication_key + " > " + str(bookmark)
                 }],
                 "requestId":
                 "all-guides"
@@ -865,7 +879,8 @@ class Pages(Stream):
     replication_method = "INCREMENTAL"
     replication_key = "lastUpdatedAt"
 
-    def get_body(self):
+    def get_body(self, bookmark):
+        # bookmark = "1637901743542"
         return {
             "response": {
                 "mimeType": "application/json"
@@ -879,6 +894,8 @@ class Pages(Stream):
                     }
                 }, {
                     "sort": ["id"]
+                }, {
+                    "filter": self.replication_key + " > " + str(bookmark)
                 }],
                 "requestId":
                 "all-pages"

--- a/tap_pendo/sync.py
+++ b/tap_pendo/sync.py
@@ -23,7 +23,7 @@ def sync_stream(state, start_date, instance):
             integer_datetime_fmt="unix-milliseconds-integer-datetime-parsing"
     ) as transformer:
         # Get records for the stream
-        (stream, records) = instance.sync(state, start_date)
+        (stream, records) = instance.sync(state)
         for record in records:
             schema_dict = stream.schema.to_dict()
             stream_metadata = metadata.to_map(stream.metadata)

--- a/tap_pendo/sync.py
+++ b/tap_pendo/sync.py
@@ -23,7 +23,7 @@ def sync_stream(state, start_date, instance):
             integer_datetime_fmt="unix-milliseconds-integer-datetime-parsing"
     ) as transformer:
         # Get records for the stream
-        (stream, records) = instance.sync(state)
+        (stream, records) = instance.sync(state, start_date)
         for record in records:
             schema_dict = stream.schema.to_dict()
             stream_metadata = metadata.to_map(stream.metadata)

--- a/tap_pendo/sync.py
+++ b/tap_pendo/sync.py
@@ -1,9 +1,9 @@
 import json
+from datetime import timedelta
 
 import humps
 import singer
 import singer.metrics as metrics
-from datetime import timedelta
 from singer import Transformer, metadata
 from singer.transform import strptime_to_utc
 from singer.utils import strftime

--- a/tests/tap_tester/test_all_fields.py
+++ b/tests/tap_tester/test_all_fields.py
@@ -61,8 +61,10 @@ class PendoAllFieldsTest(TestPendoBase):
 
                 # collect actual values
                 messages = synced_records.get(stream)
-                actual_all_keys = [set(message['data'].keys()) for message in messages['messages']
-                                   if message['action'] == 'upsert'][0]
+                actual_all_keys = set()
+                for message in messages['messages']:
+                    if message['action'] == 'upsert':
+                        actual_all_keys.update(message['data'].keys())
 
                 # Verify that more than just the automatic fields are replicated for each stream.
                 self.assertTrue(expected_automatic_keys.issubset(
@@ -80,8 +82,6 @@ class PendoAllFieldsTest(TestPendoBase):
                     expected_all_keys = expected_all_keys - {'hour', "properties"}
                 elif stream == "guide_events":
                     expected_all_keys = expected_all_keys - {'poll_response', "poll_id"}
-                elif stream == "features":
-                    expected_all_keys = expected_all_keys - {'page_id'}
                     
                 # verify all fields for each stream are replicated
                 self.assertSetEqual(expected_all_keys, actual_all_keys)

--- a/tests/tap_tester/test_all_fields.py
+++ b/tests/tap_tester/test_all_fields.py
@@ -82,8 +82,6 @@ class PendoAllFieldsTest(TestPendoBase):
                     expected_all_keys = expected_all_keys - {'poll_response', "poll_id"}
                 elif stream == "features":
                     expected_all_keys = expected_all_keys - {'page_id'}
-                elif stream == "guides":
-                    expected_all_keys = expected_all_keys - {'audience'}
                     
                 # verify all fields for each stream are replicated
                 self.assertSetEqual(expected_all_keys, actual_all_keys)

--- a/tests/tap_tester/test_child_stream_start_date.py
+++ b/tests/tap_tester/test_child_stream_start_date.py
@@ -9,7 +9,7 @@ class PendoChildStreamStartDateTest(TestPendoBase):
 
     def test_run(self):
 
-        streams_to_test = {"guides", "guide_events"}
+        streams_to_test = {"features", "feature_events"}
 
         conn_id = connections.ensure_connection(self)
 
@@ -29,34 +29,34 @@ class PendoChildStreamStartDateTest(TestPendoBase):
             self.assertGreater(record_count_by_stream.get(stream, -1), 0,
                 msg="failed to replicate any data for stream : {}".format(stream))
 
-        # collect "guide" and "guide_events" data
-        guides = synced_records.get("guides")
-        guide_events = synced_records.get("guide_events")
+        # collect "feature" and "feature_events" data
+        features = synced_records.get("features")
+        feature_events = synced_records.get("feature_events")
 
-        # find the first guide's id
-        first_guide_id = guides.get("messages")[0].get("data").get("id")
+        # find the first feature's id
+        first_feature_id = features.get("messages")[0].get("data").get("id")
 
-        first_guide_ids_events = []
-        rest_guide_events = []
+        first_feature_ids_events = []
+        rest_feature_events = []
 
-        # seperate guide events based on guide id
-        for guide_event in guide_events.get("messages"):
-            if guide_event.get("data").get("guide_id") == first_guide_id:
-                first_guide_ids_events.append(guide_event.get("data"))
+        # seperate feature events based on feature id
+        for feature_event in feature_events.get("messages"):
+            if feature_event.get("data").get("feature_id") == first_feature_id:
+                first_feature_ids_events.append(feature_event.get("data"))
             else:
-                rest_guide_events.append(guide_event.get("data"))
+                rest_feature_events.append(feature_event.get("data"))
 
-        replication_key_for_guide_events = next(iter(self.expected_replication_keys().get("guide_events")))
+        replication_key_for_feature_events = next(iter(self.expected_replication_keys().get("feature_events")))
 
-        # find the maximun bookmark date for first guide's events
-        sorted_first_guide_ids_events = sorted(first_guide_ids_events, key=lambda i: i[replication_key_for_guide_events], reverse=True)
-        max_bookmark = sorted_first_guide_ids_events[0].get(replication_key_for_guide_events)
+        # find the maximun bookmark date for first feature's events
+        sorted_first_feature_ids_events = sorted(first_feature_ids_events, key=lambda i: i[replication_key_for_feature_events], reverse=True)
+        max_bookmark = sorted_first_feature_ids_events[0].get(replication_key_for_feature_events)
 
-        # used for verifying if we synced guide events before
-        # than the maximum bookmark of first guide's events
+        # used for verifying if we synced feature events before
+        # than the maximum bookmark of first feature's events
         synced_older_data = False
-        for rest_guide_event in rest_guide_events:
-            event_time = datetime.strptime(rest_guide_event.get(replication_key_for_guide_events), "%Y-%m-%dT%H:%M:%S.%fZ")
+        for rest_feature_event in rest_feature_events:
+            event_time = datetime.strptime(rest_feature_event.get(replication_key_for_feature_events), "%Y-%m-%dT%H:%M:%S.%fZ")
             max_bookmark_time = datetime.strptime(max_bookmark, "%Y-%m-%dT%H:%M:%S.%fZ")
             if event_time < max_bookmark_time:
                 synced_older_data = True

--- a/tests/unittests/test_date_window_for_get_records.py
+++ b/tests/unittests/test_date_window_for_get_records.py
@@ -1,0 +1,58 @@
+import unittest
+import tap_pendo.streams as streams
+from unittest import mock
+from singer.utils import strftime, now
+from datetime import timedelta
+
+@mock.patch("tap_pendo.streams.Stream.update_bookmark")
+@mock.patch("tap_pendo.streams.Stream.request")
+class TestDateWindowing(unittest.TestCase):
+    
+    def test_get_records_date_window(self, mocked_request, mocked_update_bookmark):
+        """
+            Verify that get_records() function is writing bookmark after each date_window call.(30 day default window size)
+            Verify that all data from each page are returned.
+        """
+        # Config and test_data for requests
+        current_time = now()
+        config = {"start_date": strftime(current_time - timedelta(days=50))} # Start date of 50 days ago for 2 date_window call
+        
+        mocked_request.side_effect = [
+            {   # First page of test-data with 40 days ago replication-key
+                "results":[
+                    {"id": 1, "lastUpdatedAt": (current_time - timedelta(days=40)).timestamp() * 1000},
+                    {"id": 2, "lastUpdatedAt": (current_time - timedelta(days=40)).timestamp() * 1000}
+                ]
+            },
+            {   # Second page of test-data with 10 days ago replication-key
+                "results":[
+                    {"id": 3, "lastUpdatedAt": (current_time - timedelta(days=10)).timestamp() * 1000}
+                ]
+            }
+        ]
+
+        # Configure STream object and call get_records() function
+        stream_instance = streams.Stream(config)
+        stream_instance.name = "test"
+        stream_instance.replication_key = "lastUpdatedAt"
+        stream_instance.get_body = mock.Mock()
+        # Call get_records with `test` stream and bookmark of 50 days ago
+        records = list(stream_instance.get_records({}, current_time - timedelta(days=50)))
+
+        
+        expected_records = [
+            {'id': 1, 'lastUpdatedAt':(current_time - timedelta(days=40)).timestamp() * 1000},
+            {'id': 2, 'lastUpdatedAt':(current_time - timedelta(days=40)).timestamp() * 1000},
+            {'id': 3, 'lastUpdatedAt':(current_time - timedelta(days=10)).timestamp() * 1000}
+        ]
+        expected_update_bookmark_calls = [
+            # Bookmark update after first page of data(40 days ago)
+            mock.call({}, 'test', strftime(current_time - timedelta(days=40)), 'lastUpdatedAt'),
+            # Bookmark update after first page of data(10 days ago)
+            mock.call({}, 'test', strftime(current_time - timedelta(days=10)), 'lastUpdatedAt')
+        ]
+
+        # Verify that update_bookmark() is called after each page of data with expected values
+        self.assertEquals(mocked_update_bookmark.mock_calls, expected_update_bookmark_calls)
+        # Verify that all expected records from pages are returned
+        self.assertEquals(records, expected_records)

--- a/tests/unittests/test_lazy_aggregation_sync.py
+++ b/tests/unittests/test_lazy_aggregation_sync.py
@@ -2,6 +2,7 @@ import unittest
 import requests
 from unittest import mock
 from tap_pendo.streams import Visitors
+from singer.utils import now, strftime
 
 class Mockresponse:
     def __init__(self, resp, status_code, headers=None, raise_error=False):
@@ -44,17 +45,21 @@ class TestLazyAggregationSync(unittest.TestCase):
             Verify that if sub stream is present then also all data should be return for super stream
             and sync_substream should be called
         '''
-        expected_data = [{"id":1}, {"id":2}, {"id":3}]
-        records = '{"results": [{"id":1}, {"id":2}, {"id":3}]}'
+        expected_data = [{'id':1, 'metadata': {'auto': {'lastupdated': 1631515992001}}},
+                         {"id":2, 'metadata': {'auto': {'lastupdated': 1631515992001}}},
+                         {"id":3, 'metadata': {'auto': {'lastupdated': 1631515992001}}}]
+        records = '{"results": [{"id":1, "metadata": {"auto": {"lastupdated": 1631515992001}}},\
+                                {"id":2, "metadata": {"auto": {"lastupdated": 1631515992001}}},\
+                                {"id":3, "metadata": {"auto": {"lastupdated": 1631515992001}}}]}'
         mocked_selected.return_value = True # Sub stream is selected
         mocked_request.return_value = Mockresponse(records, 200, raise_error=False)
-        config = {'start_date': '2021-01-01T00:00:00Z',
+        config = {'start_date': strftime(now()),
                   'x_pendo_integration_key': 'test'}
 
         lazzy_aggr = Visitors(config)
         stream, stream_response = lazzy_aggr.sync({})
 
-        self.assertEqual(list(stream_response), expected_data) # parent stream get all expected data
+        self.assertEqual(list(stream_response)[0], expected_data[0]) # parent stream get all expected data
         self.assertEqual(mocked_substream.call_count, 1)
 
     @mock.patch("requests.Session.send")
@@ -65,11 +70,15 @@ class TestLazyAggregationSync(unittest.TestCase):
             Verify that if sub stream is not selected then also all data should be return for super stream
             and sync_substream should not be called 
         '''
-        expected_data = [{"id":1}, {"id":2}, {"id":3}]
-        records = '{"results": [{"id":1}, {"id":2}, {"id":3}]}'
+        expected_data = [{'id':1, 'metadata': {'auto': {'lastupdated': 1631515992001}}},
+                         {"id":2, 'metadata': {'auto': {'lastupdated': 1631515992001}}},
+                         {"id":3, 'metadata': {'auto': {'lastupdated': 1631515992001}}}]
+        records = '{"results": [{"id":1, "metadata": {"auto": {"lastupdated": 1631515992001}}},\
+                                {"id":2, "metadata": {"auto": {"lastupdated": 1631515992001}}},\
+                                {"id":3, "metadata": {"auto": {"lastupdated": 1631515992001}}}]}'
         mocked_selected.return_value = False # Sub stream is not selected
         mocked_request.return_value = Mockresponse(records, 200, raise_error=False)
-        config = {'start_date': '2021-01-01T00:00:00Z',
+        config = {'start_date': strftime(now()),
                   'x_pendo_integration_key': 'test'}
 
         lazzy_aggr = Visitors(config)

--- a/tests/unittests/test_lazy_aggregation_sync.py
+++ b/tests/unittests/test_lazy_aggregation_sync.py
@@ -59,7 +59,7 @@ class TestLazyAggregationSync(unittest.TestCase):
         lazzy_aggr = Visitors(config)
         stream, stream_response = lazzy_aggr.sync({})
 
-        self.assertEqual(list(stream_response)[0], expected_data[0]) # parent stream get all expected data
+        self.assertEqual(list(stream_response), expected_data) # parent stream get all expected data
         self.assertEqual(mocked_substream.call_count, 1)
 
     @mock.patch("requests.Session.send")


### PR DESCRIPTION
# Description of change
[TDL-17163](https://jira.talendforge.org/browse/TDL-17163): Reduce requested data for pages
- Currently, the tap is requesting all the data for the below streams and then writing records which are greater than a bookmark so it might cause an OOM error.
  - Accounts, Features, TrackTypes, Guides, Pages
- Pendo is not supporting any pagination directly but found one filter operator so we added a filter parameter in the request to ask for data greater than bookmark for the below streams. Reference: [ filter operator](https://developers.pendo.io/docs/?bash#operators)
  - accounts, poll_events, guide_events, guides, visitors
- visitor_history is traversing for all the parents currently so optimize it by traversing on updated visitors only.
- Made guide_events independent from a parent stream guide.
 
NOTE: Currently, page_events, feature_events, and track_events are traversing on all the parents so no way to apply date_window on it as we can not fix any starting point to traverse parents. Implement date_windowing or pagination for the same after confirmation.



# Manual QA steps
 - Run sync mode for the above-mentioned streams and verified that the same number of records are emitted compared to the old tap. Also logged length of request output to verify that we are requesting less data now.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
