### PR TITLE
Allow integer types to be treated as the strings pendo sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.4.1
+  * Allow custom metadata types to be more permissive [#97](https://github.com/singer-io/tap-pendo/pull/97)
+
 ## 0.4.0
   * Add support for EU endpoints [#95](https://github.com/singer-io/tap-pendo/pull/95)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-pendo",
-    version="0.4.0",
+    version="0.4.1",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="https://github.com/singer-io/tap-pendo",

--- a/tap_pendo/discover.py
+++ b/tap_pendo/discover.py
@@ -59,7 +59,7 @@ def get_schema_property_type(schema_type):
     elif schema_type == 'boolean':
         return {"type": ["null", "boolean"]}
     elif schema_type == 'integer':
-        return {"type": ["null", "integer"]}
+        return {"type": ["null", "integer", "number", "string"]}
     elif schema_type == 'float':
         return {"type": ["null", "number"]}
     elif schema_type == '':

--- a/tests/unittests/test_custom_fields.py
+++ b/tests/unittests/test_custom_fields.py
@@ -2,7 +2,7 @@ import unittest
 from unittest import mock
 from singer import utils, metadata
 from singer.utils import strptime_to_utc, strftime
-from tap_pendo.discover import LOGGER, build_metadata_metadata, discover_streams
+from tap_pendo.discover import LOGGER, build_metadata_metadata, discover_streams, get_schema_property_type
 from tap_pendo.streams import Stream
 
 
@@ -35,7 +35,7 @@ class TestCustomFields(unittest.TestCase):
                 "is_deleted": False,
                 "is_calculated": False,
                 "is_per_app": False,
-                "never_index": False
+                "never_index": False,
             }
         }
         # the expected schema contains all the custom fields
@@ -301,3 +301,15 @@ class TestCustomFields(unittest.TestCase):
         schema = {'properties': {}}
         build_metadata_metadata(mdata, schema, custom_visitor_fields)
         self.assertEqual(schema, expected_schema)
+
+
+    def test_get_schema_property_type(self):
+        schema_types = ['string', 'time', 'boolean', 'integer', 'float']
+
+        expected_property_types = {'boolean': {'type': ['null', 'boolean']},
+                                   'float': {'type': ['null', 'number']},
+                                   'integer': {'type': ['null', 'integer', 'number', 'string']},
+                                   'string': {'type': ['null', 'string']},
+                                   'time': {'format': 'date-time', 'type': ['null', 'string']}}
+        actual_property_types = {schema_type: get_schema_property_type(schema_type) for schema_type in schema_types}
+        self.assertEqual(actual_property_types, expected_property_types)


### PR DESCRIPTION
# Description of change
Pendo will report custom metadata fields to have a type of integer but when the tap receives the data it comes in as a string containing a decimal value. This change adds fallback types for custom metadata integers.

# Manual QA steps
 - Ran on a connection that was failing due to transformer errors because the type did not match
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
