### PR TITLE
Allow setting integration key with env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Interrupted syncs for Event type stream are resumed via a bookmark placed during
 3. Create your tap's `config.json` file. The tap config file for this tap should include these entries:
 
    - `start_date` - the default value to use if no bookmark exists for an endpoint (rfc3339 date string)
-   - `x_pendo_integration_key` (string, `ABCdef123`): an integration key from Pendo.
+   - `x_pendo_integration_key` (string, `ABCdef123`): an integration key from Pendo. If not provided in `config.json`, `X_PENDO_INTEGRATION_KEY` environment variable will be used.
    - `period` (string, `ABCdef123`): `dayRange` or `hourRange`
    - `lookback_window` (integer): 10 (For event objects. Default: 0)
    - `request_timeout` (integer): 300 (For passing timeout to the request. Default: 300)

--- a/tap_pendo/utils.py
+++ b/tap_pendo/utils.py
@@ -82,6 +82,10 @@ def parse_args(required_config_keys):
     args = parser.parse_args()
 
     config = load_json(args.config)
+    if "x_pendo_integration_key" not in config:
+        env_key = os.getenv("X_PENDO_INTEGRATION_KEY")
+        if env_key is not None:
+            config["x_pendo_integration_key"] = env_key
     check_config(config, required_config_keys) # Check config for missing fields
 
     if args.state:


### PR DESCRIPTION
# Description of change

I want to set my Pendo integration key without exposing it in a plain text `config.json` file. Following [other Singer connectors](https://github.com/ome9ax/target-s3-jsonl/), I added a few lines to `utils.py` which use environment variable `X_PENDO_INTEGRATION_KEY` if it exists and if `x_pendo_integration_key` isn't in `config.json`. It'll still throw an error if neither exists.

This would resolve #109.

# Manual QA steps
 
I actually can't get any tests to run with `python -m pytest --verbose`. Can someone more familiar with this project confirm that command runs without import errors?
 
# Risks
- This change is untested, and so shouldn't be trusted.
 
# Rollback steps
 - revert this branch

# Code style

I tried to keep things as plain and explicit as possible:

```python3
if "x_pendo_integration_key" not in config:
    env_key = os.getenv("X_PENDO_INTEGRATION_KEY")
    if env_key is not None:
        config["x_pendo_integration_key"] = env_key
```

But it may not the most succinct way to do it--or even the best way. Feel free to change this to a better way.