### PR TITLE
Tdl 19587 timeout out of memory fixes

### DIFF
--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -454,7 +454,7 @@ class LazyAggregationStream(Stream):
                 raise e from None
             # Raise error if we have retried for 5 times
             if count == 5:
-                LOGGER.info("Giving up request(...) after 5 tries (%s: %s)", e.__class__.__name__, str(e))
+                LOGGER.error("Giving up request(...) after 5 tries (%s: %s)", e.__class__.__name__, str(e))
                 raise e from None
 
             LOGGER.info("Backing off request(...) for %ss (%s: %s)", BACKOFF_FACTOR ** count, e.__class__.__name__, str(e))

--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -33,6 +33,9 @@ FACTOR = 2
 COUNT = 5
 
 def to_giveup(e):
+    """
+        Boolean function to return if we want to give up retrying based on error response
+    """
     return e.response is not None and 400 <= e.response.status_code < 500
 
 def get_abs_path(path):

--- a/tests/unittests/test_backoff.py
+++ b/tests/unittests/test_backoff.py
@@ -242,7 +242,7 @@ class TestTimeOut(unittest.TestCase):
         visitors = streams.Visitors({'x_pendo_integration_key': 'test'})
 
         try:
-            visitors.request('visitors')
+            list(visitors.request('visitors'))
         except requests.exceptions.Timeout:
             pass
 
@@ -257,7 +257,7 @@ class TestTimeOut(unittest.TestCase):
         events = streams.Events({'x_pendo_integration_key': 'test'})
 
         try:
-            events.request('events')
+            list(events.request('events'))
         except requests.exceptions.Timeout:
             pass
 
@@ -471,7 +471,7 @@ class TestConnectionResetError(unittest.TestCase):
         visitors = streams.Visitors({'x_pendo_integration_key': 'test'})
 
         try:
-            visitors.request('visitors')
+            list(visitors.request('visitors'))
         except ConnectionResetError:
             pass
 
@@ -486,7 +486,7 @@ class TestConnectionResetError(unittest.TestCase):
         events = streams.Events({'x_pendo_integration_key': 'test'})
 
         try:
-            events.request('events')
+            list(events.request('events'))
         except ConnectionResetError:
             pass
 
@@ -700,7 +700,7 @@ class TestProtocolError(unittest.TestCase):
         visitors = streams.Visitors({'x_pendo_integration_key': 'test'})
 
         try:
-            visitors.request('visitors')
+            list(visitors.request('visitors'))
         except ProtocolError:
             pass
 
@@ -715,7 +715,7 @@ class TestProtocolError(unittest.TestCase):
         events = streams.Events({'x_pendo_integration_key': 'test'})
 
         try:
-            events.request('events')
+            list(events.request('events'))
         except ProtocolError:
             pass
 
@@ -902,7 +902,7 @@ class Positive(unittest.TestCase):
         # initialize 'visitors' stream class
         visitors = streams.Visitors({'x_pendo_integration_key': 'test'})
 
-        resp = visitors.request('visitors')
+        resp = list(visitors.request('visitors'))
         
         # verify if the desired data was returned from the request
         self.assertEquals(list(resp), [json])

--- a/tests/unittests/test_backoff_for_conn_reset.py
+++ b/tests/unittests/test_backoff_for_conn_reset.py
@@ -17,7 +17,7 @@ class TestConnectionResetError(unittest.TestCase):
         mocked_send.side_effect = socket.error(104, 'Connection reset by peer')
 
         with self.assertRaises(ConnectionResetError):
-            self.stream.request(endpoint=None)
+            list(self.stream.request(endpoint=None))
 
         # verify if the request was called 5 times
         self.assertEquals(mocked_send.call_count, 5)
@@ -28,7 +28,7 @@ class TestConnectionResetError(unittest.TestCase):
         mocked_request.side_effect = socket.error(104, 'Connection reset by peer')
 
         with self.assertRaises(ProtocolError):
-            self.stream.request(endpoint=None)
+            list(self.stream.request(endpoint=None))
 
         # verify if the request was called 5 times
         self.assertEquals(mocked_request.call_count, 5)
@@ -39,7 +39,7 @@ class TestConnectionResetError(unittest.TestCase):
         mocked_request.side_effect = socket.timeout('The read operation timed out')
 
         with self.assertRaises(ReadTimeoutError):
-            self.stream.request(endpoint=None)
+            list(self.stream.request(endpoint=None))
 
         # verify if the request was called 5 times
         self.assertEquals(mocked_request.call_count, 5)

--- a/tests/unittests/test_backoff_for_conn_reset.py
+++ b/tests/unittests/test_backoff_for_conn_reset.py
@@ -4,6 +4,38 @@ from tap_pendo.streams import Endpoints, Visitors
 import unittest
 import socket
 from requests.models import ProtocolError
+import requests
+
+class Mockresponse:
+    def __init__(self, status_code, raise_error, headers=None):
+        self.status_code = status_code
+        self.raise_error = raise_error
+        self.headers = headers
+        self.reason = "test"
+        self.raw = '{"results": [{"key1": "value1", "key2": "value2"}]}'
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return True
+
+    def raise_for_status(self):
+        if not self.raise_error:
+            return self.status_code
+
+        raise requests.HTTPError("Sample message")
+
+    def close(self):
+        return True
+
+def get_response():
+    return Mockresponse(200, False)
+
+# def mocked_ijson(*args, **kwargs):
+def items(*args, **kwargs):
+    raise ConnectionResetError("Connection is reset.")
+    yield {"key1": "value1", "key2": "value2"}
 
 @mock.patch("time.sleep")
 class TestConnectionResetError(unittest.TestCase):
@@ -43,3 +75,20 @@ class TestConnectionResetError(unittest.TestCase):
 
         # verify if the request was called 5 times
         self.assertEquals(mocked_request.call_count, 5)
+
+    @mock.patch('requests.Session.send')
+    @mock.patch('ijson.items')
+    def test_error__from_ijson(self, mocked_ijson_items, mocked_send, mocked_sleep):
+        """
+            Test case to verify we backoff for errors raised from 'ijson.items'
+        """
+        # mock request and return dummy data
+        mocked_send.return_value = get_response()
+        # mock ijson.items and replace with generator function that raises error
+        mocked_ijson_items.side_effect = items
+
+        with self.assertRaises(ConnectionError):
+            list(self.stream.request(endpoint=None))
+
+        # verify if the request was called 5 times
+        self.assertEquals(mocked_send.call_count, 5)

--- a/tests/unittests/test_timeout_value.py
+++ b/tests/unittests/test_timeout_value.py
@@ -47,7 +47,7 @@ class TestTimeOutValue(unittest.TestCase):
         # pass 'request_timeout' param in the config
         stream = streams.Stream({'x_pendo_integration_key': 'test', 'request_timeout': 100})
 
-        stream.send_request_get_results('test_req')
+        stream.send_request_get_results('test_req', None, {}, 1)
 
         # verify if the request was called with the desired timeout
         mocked_send.assert_called_with('test_req', timeout=100.0)
@@ -63,7 +63,7 @@ class TestTimeOutValue(unittest.TestCase):
         # not pass 'request_timeout' param in the config
         stream = streams.Stream({'x_pendo_integration_key': 'test'})
 
-        stream.send_request_get_results('test_req')
+        stream.send_request_get_results('test_req', None, {}, 1)
 
         # verify if the request was called with default timeout
         mocked_send.assert_called_with('test_req', timeout=300.0)
@@ -79,7 +79,7 @@ class TestTimeOutValue(unittest.TestCase):
         # pass string value of 'request_timeout' in the config
         stream = streams.Stream({'x_pendo_integration_key': 'test', 'request_timeout': "100"})
 
-        stream.send_request_get_results('test_req')
+        stream.send_request_get_results('test_req', None, {}, 1)
 
         # verify if the request was called with passed timeout param
         mocked_send.assert_called_with('test_req', timeout=100.0)
@@ -95,7 +95,7 @@ class TestTimeOutValue(unittest.TestCase):
         # pass empty string value of 'request_timeout' in the config
         stream = streams.Stream({'x_pendo_integration_key': 'test', 'request_timeout': ""})
 
-        stream.send_request_get_results('test_req')
+        stream.send_request_get_results('test_req', None, {}, 1)
 
         # verify if the request was called with passed timeout param
         mocked_send.assert_called_with('test_req', timeout=300.0)
@@ -111,7 +111,7 @@ class TestTimeOutValue(unittest.TestCase):
         # pass empty string value of 'request_timeout' in the config
         stream = streams.Stream({'x_pendo_integration_key': 'test', 'request_timeout': 0.0})
 
-        stream.send_request_get_results('test_req')
+        stream.send_request_get_results('test_req', None, {}, 1)
 
         # verify if the request was called with passed timeout param
         mocked_send.assert_called_with('test_req', timeout=300.0)
@@ -127,7 +127,7 @@ class TestTimeOutValue(unittest.TestCase):
         # pass empty string value of 'request_timeout' in the config
         stream = streams.Stream({'x_pendo_integration_key': 'test', 'request_timeout': "0.0"})
 
-        stream.send_request_get_results('test_req')
+        stream.send_request_get_results('test_req', None, {}, 1)
 
         # verify if the request was called with passed timeout param
         mocked_send.assert_called_with('test_req', timeout=300.0)
@@ -142,7 +142,7 @@ class TestTimeOutValue(unittest.TestCase):
         # pass 'request_timeout' param in the config
         stream = streams.LazyAggregationStream({'x_pendo_integration_key': 'test', 'request_timeout': 100})
 
-        stream.send_request_get_results('test_req')
+        list(stream.send_request_get_results('test_req', None, {}, 1))
 
         # verify if the request was called with the desired timeout
         mocked_send.assert_called_with('test_req', stream=True, timeout=100.0)
@@ -158,7 +158,7 @@ class TestTimeOutValue(unittest.TestCase):
         # not pass 'request_timeout' param in the config
         stream = streams.LazyAggregationStream({'x_pendo_integration_key': 'test'})
 
-        stream.send_request_get_results('test_req')
+        list(stream.send_request_get_results('test_req', None, {}, 1))
 
         # verify if the request was called with default timeout
         mocked_send.assert_called_with('test_req', stream=True, timeout=300.0)
@@ -174,7 +174,7 @@ class TestTimeOutValue(unittest.TestCase):
         # pass string value of 'request_timeout' in the config
         stream = streams.LazyAggregationStream({'x_pendo_integration_key': 'test', 'request_timeout': "100"})
 
-        stream.send_request_get_results('test_req')
+        list(stream.send_request_get_results('test_req', None, {}, 1))
 
         # verify if the request was called with passed timeout param
         mocked_send.assert_called_with('test_req', stream=True, timeout=100.0)
@@ -190,7 +190,7 @@ class TestTimeOutValue(unittest.TestCase):
         # pass string value of 'request_timeout' in the config
         stream = streams.LazyAggregationStream({'x_pendo_integration_key': 'test', 'request_timeout': ""})
 
-        stream.send_request_get_results('test_req')
+        list(stream.send_request_get_results('test_req', None, {}, 1))
 
         # verify if the request was called with passed timeout param
         mocked_send.assert_called_with('test_req', stream=True, timeout=300.0)
@@ -206,7 +206,7 @@ class TestTimeOutValue(unittest.TestCase):
         # pass string value of 'request_timeout' in the config
         stream = streams.LazyAggregationStream({'x_pendo_integration_key': 'test', 'request_timeout': 0.0})
 
-        stream.send_request_get_results('test_req')
+        list(stream.send_request_get_results('test_req', None, {}, 1))
 
         # verify if the request was called with passed timeout param
         mocked_send.assert_called_with('test_req', stream=True, timeout=300.0)
@@ -222,7 +222,7 @@ class TestTimeOutValue(unittest.TestCase):
         # pass string value of 'request_timeout' in the config
         stream = streams.LazyAggregationStream({'x_pendo_integration_key': 'test', 'request_timeout': "0.0"})
 
-        stream.send_request_get_results('test_req')
+        list(stream.send_request_get_results('test_req', None, {}, 1))
 
         # verify if the request was called with passed timeout param
         mocked_send.assert_called_with('test_req', stream=True, timeout=300.0)


### PR DESCRIPTION
# Description of change
- Current tap implementation sometime generates large response with more than 150K records for event streams which may cause Timeout and Out-of-Memory issues. So to limit response size, added property `record_limit` default value 100K.
- Updated implementation for following event sub-streams
	- Feature Events
	- Page Events
	- Track Events
	- Guide Events
- Tried to enhance Visitor history but could not find optimum solution
- Refactored the event streams

# Manual QA steps
 - Tested discovery and sync for event streams above
 - Tap-tester test execution pending till [Connections-service PR#1551](https://github.com/stitchdata/connections-service/pull/1551)
 
# Risks
 - Fix comes with performance impact if `record_limit` set smaller
 - Timeout is still a possibility from Pendo server side
 
# Rollback steps
 - revert this branch
