### PR TITLE
Tdl 21520 skip donotprocess records

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,12 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-pendo/bin/activate
             # TODO: Adjust the pylint disables
-            pylint tap_pendo --disable "$PYLINT_DISABLE_LIST,bad-whitespace,missing-class-docstring,too-many-statements"
+            pylint tap_pendo --disable 'broad-except,chained-comparison,empty-docstring,fixme,
+            invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,
+            missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,
+            too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,
+            wrong-spelling-in-comment,wrong-spelling-in-docstring,bad-whitespace,
+            missing-class-docstring,too-many-statements'
       - run:
           name: 'Unit Tests'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-pendo/bin/activate
             # TODO: Adjust the pylint disables
-            pylint tap_pendo --disable 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,bad-whitespace,missing-class-docstring'
+            pylint tap_pendo --disable 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,bad-whitespace,missing-class-docstring,too-many-statements'
       - run:
           name: 'Unit Tests'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-pendo/bin/activate
             # TODO: Adjust the pylint disables
-            pylint tap_pendo --disable 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,bad-whitespace,missing-class-docstring,too-many-statements'
+            pylint tap_pendo --disable "$PYLINT_DISABLE_LIST,bad-whitespace,missing-class-docstring,too-many-statements"
       - run:
           name: 'Unit Tests'
           command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
+## 0.5.1
+  * Skips visitor_history records for visitors with Do Not Process flag [#115](https://github.com/singer-io/tap-pendo/pull/115)
+
 ## 0.5.0
-  * Fixed connection reset and read timeout errors (https://github.com/singer-io/tap-pendo/pull/102)
+  * Fixed connection reset and read timeout errors [#102](https://github.com/singer-io/tap-pendo/pull/102)
   * Implemented new bookmark strategy for child streams to boost the extracation performance
   * Added custom pagination mechanism to fix out-of-memory issues
   * Fixed interrupted sync
@@ -53,8 +56,8 @@
 
 ## 0.0.11
   * Fix for discovering all custom fields in `visitors` and `accounts` [#27](https://github.com/singer-io/tap-pendo/pull/27)
-  * Add boolean type handling to custom field discovery [#27](https://github.com/singer-io/tap-pendo/pull/27)
-  * When matching custom field types, any unknown type will raise an exception where the error occurred, rather than generating an invalid schema [#27](https://github.com/singer-io/tap-pendo/pull/27)
+  * Add boolean type handling to custom field discovery
+  * When matching custom field types, any unknown type will raise an exception where the error occurred, rather than generating an invalid schema
 
 ## 0.0.10
   * Allow for Discovery to succeed when no custom metadata is found [#22](https://github.com/singer-io/tap-pendo/pull/22)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-pendo",
-    version="0.5.0",
+    version="0.5.1",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="https://github.com/singer-io/tap-pendo",

--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -379,7 +379,7 @@ class Stream():
                 if isinstance(parent, Visitors):
                     if record['metadata'].get('pendo', {'donotprocess': False}).get('donotprocess'):
                         # If any visitor is set the Do Not Process flag then Pendo will stop collecting events
-                        # from that visitor and will stop displaying guides to that visitor
+                        # from that visitor and its records will be missing required keys, so we must skip it.
                         LOGGER.info("Record marked as 'Do Not Process': %s", record[parent.key_properties[0]])
                         continue
 

--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -385,8 +385,8 @@ class Stream():
 
                     last_processed = self.get_last_processed(state, sub_stream)
                     # If there is no last_update key then set 'last_updated=now()' and fetch the records from recent bookmark
-                    parent_last_updated = datetime.fromtimestamp(float(
-                        record['metadata']['auto'][self.replication_key]) / 1000.0, timezone.utc) if record['metadata']['auto'].get(self.replication_key) else now()
+                    parent_last_updated = datetime.fromtimestamp(float(record['metadata']['auto'].get(
+                        self.replication_key, now().timestamp() * 1000)) / 1000.0, timezone.utc)
 
                 if isinstance(parent, Visitors) and bookmark_dttm > parent_last_updated + timedelta(days=1):
                     LOGGER.info("No new updated records for visitor id: %s", record[parent.key_properties[0]])

--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -383,7 +383,14 @@ class Stream():
                     # date window after parent last updated will be skipped
                     if record['metadata']['auto'].get(self.replication_key):
                         parent_last_updated = datetime.fromtimestamp(float(record['metadata']['auto'][self.replication_key]) / 1000.0, timezone.utc)
+                    elif record['metadata'].get('pendo', {'donotprocess': False}).get('donotprocess'):
+                        # If any visitor is set the Do Not Process flag then Pendo will stop collecting events
+                        # from that visitor and will stop displaying guides to that visitor
+                        LOGGER.info("Record marked as 'Do Not Process': %s", record[parent.key_properties[0]])
+                        continue
                     else:
+                        # If both conditions are unsatisfied then as fallback we will set last updated
+                        # to latest timestamp and fetch records from recent bookmark
                         parent_last_updated = now()
 
                 if isinstance(parent, Visitors) and bookmark_dttm > parent_last_updated + timedelta(days=1):

--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -379,7 +379,12 @@ class Stream():
                 # Filtering the visitors based on last updated to improve performance of visitor_history replication
                 if isinstance(parent, Visitors):
                     last_processed = self.get_last_processed(state, sub_stream)
-                    parent_last_updated = datetime.fromtimestamp(float(record['metadata']['auto'][self.replication_key]) / 1000.0, timezone.utc)
+
+                    # date window after parent last updated will be skipped
+                    if record['metadata']['auto'].get(self.replication_key):
+                        parent_last_updated = datetime.fromtimestamp(float(record['metadata']['auto'][self.replication_key]) / 1000.0, timezone.utc)
+                    else:
+                        parent_last_updated = now()
 
                 if isinstance(parent, Visitors) and bookmark_dttm > parent_last_updated + timedelta(days=1):
                     LOGGER.info("No new updated records for visitor id: %s", record[parent.key_properties[0]])

--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -334,7 +334,6 @@ class Stream():
         # On ressuming, once replication of bookmarked parent_id is done, for next parent_id replication should start from original bookmark
         self.update_bookmark(state=state, stream=sub_stream.name, bookmark_value=previous_sync_completed_ts, bookmark_key="previous_sync_completed_ts")
 
-
     def sync_substream(self, state, parent, sub_stream, parent_response):
         # If last sync was interrupted, get last processed parent record
         last_processed = self.get_last_processed(state, sub_stream)
@@ -378,20 +377,16 @@ class Stream():
 
                 # Filtering the visitors based on last updated to improve performance of visitor_history replication
                 if isinstance(parent, Visitors):
-                    last_processed = self.get_last_processed(state, sub_stream)
-
-                    # date window after parent last updated will be skipped
-                    if record['metadata']['auto'].get(self.replication_key):
-                        parent_last_updated = datetime.fromtimestamp(float(record['metadata']['auto'][self.replication_key]) / 1000.0, timezone.utc)
-                    elif record['metadata'].get('pendo', {'donotprocess': False}).get('donotprocess'):
+                    if record['metadata'].get('pendo', {'donotprocess': False}).get('donotprocess'):
                         # If any visitor is set the Do Not Process flag then Pendo will stop collecting events
                         # from that visitor and will stop displaying guides to that visitor
                         LOGGER.info("Record marked as 'Do Not Process': %s", record[parent.key_properties[0]])
                         continue
-                    else:
-                        # If both conditions are unsatisfied then as fallback we will set last updated
-                        # to latest timestamp and fetch records from recent bookmark
-                        parent_last_updated = now()
+
+                    last_processed = self.get_last_processed(state, sub_stream)
+                    # If there is no last_update key then set 'last_updated=now()' and fetch the records from recent bookmark
+                    parent_last_updated = datetime.fromtimestamp(float(
+                        record['metadata']['auto'][self.replication_key]) / 1000.0, timezone.utc) if record['metadata']['auto'].get(self.replication_key) else now()
 
                 if isinstance(parent, Visitors) and bookmark_dttm > parent_last_updated + timedelta(days=1):
                     LOGGER.info("No new updated records for visitor id: %s", record[parent.key_properties[0]])


### PR DESCRIPTION
# Description of change
If any visitor is set the Do Not Process flag then Pendo will stop collecting events from that visitor and will stop displaying guides to that visitor. In such scenario we should skip fetching visitor_history.

# Manual QA steps
 - On cloned connection verified that `donotprocess` records are getting skipped.
 - Updated 'donotprocess' of few visitors in the test account to cover this scenario in the integration tests
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
