### PR TITLE
Add filter parameter and record limit to resolve OOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,8 +262,13 @@ Interrupted syncs for Event type stream are resumed via a bookmark placed during
    - `start_date` - the default value to use if no bookmark exists for an endpoint (rfc3339 date string)
    - `x_pendo_integration_key` (string, `ABCdef123`): an integration key from Pendo.
    - `period` (string, `ABCdef123`): `dayRange` or `hourRange`
-   - `lookback_window` (integer): 10 (For event objects. Default: 0)
-   - `request_timeout` (integer): 300 (For passing timeout to the request. Default: 300)
+   - `lookback_window` (integer, 10): For event objects. Default: 0 days
+   - `request_timeout` (integer, 300) For passing timeout to the request. Default: 300 seconds
+   - `record_limit` (integer, 100000): maximum number of records Pendo API can retrieve in a single request. Default: 100000 records
+
+   ```
+   Note: It is important to set `record_limit` parameter to an appropriate value, as selecting a smaller value may have a negative effect on the Pendo API's performance, while a larger value may result in connection errors, request timeouts, or memory overflows.
+   ```
 
    ```json
    {
@@ -272,6 +277,7 @@ Interrupted syncs for Event type stream are resumed via a bookmark placed during
      "period": "dayRange",
      "lookback_window": 10,
      "request_timeout": 300,
+     "record_limit": 100000,
      "include_anonymous_visitors": "true"
    }
    ```

--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -599,8 +599,10 @@ class Stream():
             sub_stream = None
 
         # If last processed records exists, then set first to timestamp of first record
-        first = self.last_processed[0][humps.decamelize(
-            self.replication_key)] if self.last_processed else int(start_date.timestamp()) * 1000
+        if self.last_processed:
+            first = self.last_processed[0][humps.decamelize(self.replication_key)]
+        else:
+            first = int(start_date.timestamp()) * 1000
 
         # Setup body for first request
         body = self.get_body()

--- a/tap_pendo/sync.py
+++ b/tap_pendo/sync.py
@@ -22,45 +22,47 @@ def sync_stream(state, start_date, instance):
     with metrics.record_counter(stream.tap_stream_id) as counter, Transformer(
             integer_datetime_fmt="unix-milliseconds-integer-datetime-parsing"
     ) as transformer:
-        # Get records for the stream
-        (stream, records) = instance.sync(state)
-        for record in records:
-            schema_dict = stream.schema.to_dict()
-            stream_metadata = metadata.to_map(stream.metadata)
+        incomplete_sync = True
+        while incomplete_sync:
+            # Get records for the stream
+            (stream, records), incomplete_sync = instance.sync(state, new_bookmark)
+            for record in records:
+                schema_dict = stream.schema.to_dict()
+                stream_metadata = metadata.to_map(stream.metadata)
 
-            transformed_record = instance.transform(record)
+                transformed_record = instance.transform(record)
 
-            # Transform record as per field selection in metadata
-            try:
-                transformed_record = transformer.transform(
-                    transformed_record, schema_dict, stream_metadata)
-            except Exception as err:
-                LOGGER.error('Error: %s', err)
-                LOGGER.error(' for schema: %s',
-                             json.dumps(schema_dict, sort_keys=True, indent=2))
-                LOGGER.error('Transform failed for %s', record)
-                raise err
+                # Transform record as per field selection in metadata
+                try:
+                    transformed_record = transformer.transform(
+                        transformed_record, schema_dict, stream_metadata)
+                except Exception as err:
+                    LOGGER.error('Error: %s', err)
+                    LOGGER.error(' for schema: %s',
+                                json.dumps(schema_dict, sort_keys=True, indent=2))
+                    LOGGER.error('Transform failed for %s', record)
+                    raise err
 
-            # Check for replication_value from record and if value found then use it for updating bookmark
-            replication_value = transformed_record.get(
-                humps.decamelize(instance.replication_key))
-            if replication_value:
-                record_timestamp = strptime_to_utc(replication_value)
-                new_bookmark = max(new_bookmark, record_timestamp)
+                # Check for replication_value from record and if value found then use it for updating bookmark
+                replication_value = transformed_record.get(
+                    humps.decamelize(instance.replication_key))
+                if replication_value:
+                    record_timestamp = strptime_to_utc(replication_value)
+                    new_bookmark = max(new_bookmark, record_timestamp)
 
-                if record_timestamp >= bookmark_dttm:
+                    if record_timestamp >= bookmark_dttm:
+                        singer.write_record(stream.tap_stream_id, transformed_record)
+                        counter.increment()
+
+                else: # No replication_value found then write record without considering for bookmark
                     singer.write_record(stream.tap_stream_id, transformed_record)
+                    LOGGER.info('Replication Value NULL for tap_stream_id: %s', stream.tap_stream_id)
                     counter.increment()
 
-            else: # No replication_value found then write record without considering for bookmark
-                singer.write_record(stream.tap_stream_id, transformed_record)
-                LOGGER.info('Replication Value NULL for tap_stream_id: %s', stream.tap_stream_id)
-                counter.increment()
-
-        # Update bookmark and write state for the stream with new_bookmark
-        instance.update_bookmark(state, instance.name, strftime(new_bookmark),
-                                 instance.replication_key)
-        singer.write_state(state)
+            # Update bookmark and write state for the stream with new_bookmark
+            instance.update_bookmark(state, instance.name, strftime(new_bookmark),
+                                    instance.replication_key)
+            singer.write_state(state)
 
         return counter.value
 

--- a/tap_pendo/sync.py
+++ b/tap_pendo/sync.py
@@ -22,10 +22,10 @@ def sync_stream(state, start_date, instance):
     with metrics.record_counter(stream.tap_stream_id) as counter, Transformer(
             integer_datetime_fmt="unix-milliseconds-integer-datetime-parsing"
     ) as transformer:
-        incomplete_sync = True
-        while incomplete_sync:
+        loop_for_records = True
+        while loop_for_records:
             # Get records for the stream
-            (stream, records), incomplete_sync = instance.sync(state, new_bookmark)
+            (stream, records), loop_for_records = instance.sync(state, new_bookmark)
             for record in records:
                 schema_dict = stream.schema.to_dict()
                 stream_metadata = metadata.to_map(stream.metadata)

--- a/tap_pendo/sync.py
+++ b/tap_pendo/sync.py
@@ -39,7 +39,7 @@ def sync_stream(state, start_date, instance):
                 except Exception as err:
                     LOGGER.error('Error: %s', err)
                     LOGGER.error(' for schema: %s',
-                                json.dumps(schema_dict, sort_keys=True, indent=2))
+                                 json.dumps(schema_dict, sort_keys=True, indent=2))
                     LOGGER.error('Transform failed for %s', record)
                     raise err
 
@@ -61,7 +61,7 @@ def sync_stream(state, start_date, instance):
 
             # Update bookmark and write state for the stream with new_bookmark
             instance.update_bookmark(state, instance.name, strftime(new_bookmark),
-                                    instance.replication_key)
+                                     instance.replication_key)
             singer.write_state(state)
 
         return counter.value

--- a/tests/unittests/test_backoff.py
+++ b/tests/unittests/test_backoff.py
@@ -951,4 +951,4 @@ class Positive(unittest.TestCase):
         resp = events.request('events')
         
         # verify if the desired data was returned from the request
-        self.assertEquals(list(resp), [json])
+        self.assertEquals(resp, json)

--- a/tests/unittests/test_child_stream_start_date.py
+++ b/tests/unittests/test_child_stream_start_date.py
@@ -40,8 +40,8 @@ class ChildStream:
         # append 'args' in the TEST variable for assertion
         TEST.append(args)
         # return dummy data
-        return [{"id": 1, "date": "2021-02-01T00:00:00Z"},
-                {"id": 2, "date": "2021-03-01T00:00:00Z"}], False
+        return ("stream", [{"id": 1, "date": "2021-02-01T00:00:00Z"},
+                           {"id": 2, "date": "2021-03-01T00:00:00Z"}]), False
 
     def __init__(self, config):
         self.config = config

--- a/tests/unittests/test_incremental.py
+++ b/tests/unittests/test_incremental.py
@@ -38,7 +38,7 @@ class TestIncremental(unittest.TestCase):
         mock_start_date = "2021-01-10T00:00:00Z"
         mock_records = [{"id":1, "lastupdated": "2021-01-12T00:00:00Z"},
                         {"id":2, "lastupdated": "2021-01-15T00:00:00Z"}]
-        mocked_sync.return_value = MockStream('test'), mock_records
+        mocked_sync.return_value = (MockStream('test'), mock_records), False
 
         stream_instance = streams.Stream(mock_config)
         stream_instance.replication_key = 'lastupdated'
@@ -57,7 +57,7 @@ class TestIncremental(unittest.TestCase):
         mock_start_date = "2021-01-10T00:00:00Z"
         mock_records = [{"id":1, "lastupdated": "2021-01-12T00:00:00Z"},
                         {"id":2, "lastupdated": "2021-01-08T00:00:00Z"}]
-        mocked_sync.return_value = MockStream('test'), mock_records
+        mocked_sync.return_value = (MockStream('test'), mock_records), False
 
         stream_instance = streams.Stream(mock_config)
         stream_instance.replication_key = 'lastupdated'
@@ -76,7 +76,7 @@ class TestIncremental(unittest.TestCase):
         mock_start_date = "2021-01-10T00:00:00Z"
         mock_records = [{"id":1, "lastupdated": "2021-01-01T00:00:00Z"},
                         {"id":2, "lastupdated": "2021-01-08T00:00:00Z"}]
-        mocked_sync.return_value = MockStream('test'), mock_records
+        mocked_sync.return_value = (MockStream('test'), mock_records), False
 
         stream_instance = streams.Stream(mock_config)
         stream_instance.replication_key = 'lastupdated'

--- a/tests/unittests/test_lazy_aggregation_sync.py
+++ b/tests/unittests/test_lazy_aggregation_sync.py
@@ -52,7 +52,7 @@ class TestLazyAggregationSync(unittest.TestCase):
                   'x_pendo_integration_key': 'test'}
 
         lazzy_aggr = Visitors(config)
-        stream, stream_response = lazzy_aggr.sync({})
+        (_, stream_response), _ = lazzy_aggr.sync({})
 
         self.assertEqual(list(stream_response), expected_data) # parent stream get all expected data
         self.assertEqual(mocked_substream.call_count, 1)
@@ -73,7 +73,7 @@ class TestLazyAggregationSync(unittest.TestCase):
                   'x_pendo_integration_key': 'test'}
 
         lazzy_aggr = Visitors(config)
-        stream, stream_response = lazzy_aggr.sync({})
+        (_, stream_response), _ = lazzy_aggr.sync({})
 
         self.assertEqual(list(stream_response), expected_data)
         self.assertEqual(mocked_substream.call_count, 0)

--- a/tests/unittests/test_none_date.py
+++ b/tests/unittests/test_none_date.py
@@ -41,7 +41,7 @@ class TestNoneReplicatioKeys(unittest.TestCase):
         mock_start_date = "2021-01-01T00:00:00Z"
         mock_records = [{"id":1, "lastupdated": "2021-09-01T00:00:00Z"},
                         {"id":2, "lastupdated": "2021-09-02T00:00:00Z"}]
-        mocked_sync.return_value = MockStream('test'), mock_records
+        mocked_sync.return_value = (MockStream('test'), mock_records), False
 
         stream_instance = streams.Stream(mock_config)
         stream_instance.name = 'test'
@@ -69,7 +69,7 @@ class TestNoneReplicatioKeys(unittest.TestCase):
         mock_records = [{"id":1},# No replication key present
                         {"id":2, "lastupdated": "2021-09-01T00:00:00Z"},
                         {"id":3, "lastupdated": None}] # Replication key with None value
-        mocked_sync.return_value = MockStream('test'), mock_records
+        mocked_sync.return_value = (MockStream('test'), mock_records), False
 
         stream_instance = streams.Stream(mock_config)
         stream_instance.name = 'test'
@@ -103,7 +103,7 @@ class TestNoneReplicatioKeysInSubStreams(unittest.TestCase):
         mock_parent_data = [{"id": 1}]
         mock_records = [{"id":1, "lastupdated": "2021-09-01T00:00:00Z"},
                         {"id":2, "lastupdated": "2021-09-02T00:00:00Z"}]
-        mocked_sync.return_value = mock_records, False
+        mocked_sync.return_value = (MockStream('test'), mock_records), False
 
         parent_instance = streams.Stream(mock_config)
         sub_stream = streams.Stream(mock_config)
@@ -133,7 +133,7 @@ class TestNoneReplicatioKeysInSubStreams(unittest.TestCase):
         mock_records = [{"id":1},# No replication key present
                         {"id":2, "lastupdated": "2021-09-01T00:00:00Z"},
                         {"id":3, "lastupdated": None}] # Replication key with None value
-        mocked_sync.return_value = mock_records, False
+        mocked_sync.return_value = (MockStream('test'), mock_records), False
 
         parent_instance = streams.Stream(mock_config)
         sub_stream = streams.Stream(mock_config)

--- a/tests/unittests/test_parent_stream_sync.py
+++ b/tests/unittests/test_parent_stream_sync.py
@@ -1,0 +1,123 @@
+import unittest
+from unittest import mock
+import humps
+
+from parameterized import parameterized
+from tap_pendo.streams import *
+
+default_config = {
+        "record_limit": 10,
+        "request_timeout": 10,
+        "period": "hourRage"
+    }
+
+default_kwargs = {"key_id": "key_id", "period": "hour", "first": 1}
+
+
+class TestPendoParentStreams(unittest.TestCase):
+    last_processed_index = 0
+    test_records = []
+    record_limit = 0
+
+    def generate_records(self, stream_obj, num_records, num_same_replication_value=0):
+        test_records = []
+        offset = 1000000
+        replication_key = humps.decamelize(stream_obj.replication_key)
+
+        if isinstance(stream_obj, Accounts):
+            test_records = [{"appID": 10000, "metadata": {"auto": {"lastupdated": offset+i}}} for i in range(num_records)]
+            for i in range(num_records, num_records+num_same_replication_value):
+                test_records.append({"appID": 10000, "metadata": {"auto": {"lastupdated": offset+num_records+10}}})
+        else:
+            test_records = [{"appID": 10000, replication_key: offset+i} for i in range(num_records)]
+            for i in range(num_records, num_records+num_same_replication_value):
+                test_records.append({"id": 10000, replication_key: offset+num_records})
+
+        return test_records
+    
+    @parameterized.expand(
+        [(Accounts, "accounts", None, "metadata.auto.lastupdated", None),
+        (Features, "features", None, "lastUpdatedAt", None),
+        (TrackTypes, "trackTypes", None, "lastUpdatedAt", None),
+        (Guides, "guides", None, "lastUpdatedAt", None),
+        (Pages, "pages", None, "lastUpdatedAt", None),
+        (Events, "events", None, "hour", default_kwargs),
+        (GuideEvents, "guideEvents", {"guideId": "key_id",}, "browser_time", default_kwargs),
+        (FeatureEvents, "featureEvents", {"featureId": "key_id",}, "hour", default_kwargs),
+        (PollEvents, "pollEvents", None, "browser_time", default_kwargs),
+        (TrackEvents, "trackEvents", {"trackTypeId": "key_id",}, "hour", default_kwargs)])
+    def test_get_body(self, stream_class, exp_event_type, exp_event_type_value, exp_filter_key, kwargs):
+        """Verify get_body method returns an expected request body object"""
+        stream_obj = stream_class(default_config)
+        # body = stream_obj.get_body()
+        body = stream_obj.get_body(**kwargs) if kwargs else stream_obj.get_body()
+        sort_index = stream_obj.get_pipeline_key_index(body, "sort")
+        filter_index = stream_obj.get_pipeline_key_index(body, "filter")
+        limit_index = stream_obj.get_pipeline_key_index(body, "limit")
+        
+        self.assertIn(exp_event_type, body["request"]["pipeline"][0]["source"])
+
+        if kwargs:
+            self.assertIn("timeSeries", body["request"]["pipeline"][0]["source"])
+
+        self.assertEqual(body["request"]["pipeline"][0]["source"][exp_event_type], exp_event_type_value)
+        self.assertEqual(body["request"]["pipeline"][sort_index]["sort"], [humps.camelize(exp_filter_key)])
+        self.assertEqual(body["request"]["pipeline"][filter_index]["filter"], f"{humps.camelize(exp_filter_key)}>=1")
+        self.assertEqual(body["request"]["pipeline"][limit_index]["limit"], stream_obj.record_limit)
+
+    @parameterized.expand(
+        [(Accounts, "metadata.auto.lastupdated", None),
+        (Features, "lastUpdatedAt", None),
+        (TrackTypes,"lastUpdatedAt", None),
+        (Events, "hour", default_kwargs),
+        (PollEvents, "browserTime", default_kwargs),
+        (GuideEvents, "browserTime", default_kwargs)])
+    def test_set_request_body_filters(self, stream_class, exp_filter_key, kwargs):
+        """Verify set_request_body_filters method sets filter parameter correctly in request body object"""
+        stream_obj = stream_class(default_config)
+        body = stream_obj.get_body(**kwargs) if kwargs else stream_obj.get_body()
+        test_records = self.generate_records(stream_obj, 10)
+        body = stream_obj.set_request_body_filters(body=body,
+                                                   start_time=100000,
+                                                   records=test_records)
+
+        self.assertEqual(body, body)
+        filter_index = stream_obj.get_pipeline_key_index(body, "filter")
+        camelized_replication_key = humps.camelize(exp_filter_key)
+        decamelized_replication_key = humps.decamelize(exp_filter_key)
+
+        if isinstance(stream_obj, Accounts):
+            replication_key_value = test_records[-1]["metadata"]["auto"]["lastupdated"]
+        else:
+            replication_key_value = test_records[-1][decamelized_replication_key]
+            
+        self.assertEqual(body["request"]["pipeline"][filter_index]["filter"],
+                        f"{camelized_replication_key}>={replication_key_value}")
+
+    
+    @parameterized.expand(
+        [(Accounts,),
+        (Features,),
+        (TrackTypes,),
+        (Events,),
+        (PollEvents,),
+        (GuideEvents,)])
+    def test_remove_last_timestamp_records(self, stream_class):
+        """ Verify response records are manipulated/removed as expected """
+        stream_obj = stream_class(default_config)
+        record_limit = stream_obj.record_limit  # original record limit value
+ 
+        # Verify if records have distinct replication key value then only one record is removed
+        test_records = self.generate_records(stream_obj, 10)
+        self.assertEqual(len(stream_obj.remove_last_timestamp_records(test_records)), 1)
+        self.assertEqual(stream_obj.record_limit, record_limit)
+
+        # Verify if records have 'nn distinct replication key value then 'n' record is removed
+        test_records = self.generate_records(stream_obj, 10, 5)
+        self.assertEqual(len(stream_obj.remove_last_timestamp_records(test_records)), 5)
+        self.assertEqual(stream_obj.record_limit, record_limit)
+
+        # Verify if all records have equal replication key value then record limit is set to default
+        test_records = self.generate_records(stream_obj, 0, record_limit)
+        self.assertEqual(len(stream_obj.remove_last_timestamp_records(test_records)), record_limit)
+        self.assertEqual(stream_obj.record_limit, API_RECORD_LIMIT)

--- a/tests/unittests/test_parent_stream_sync.py
+++ b/tests/unittests/test_parent_stream_sync.py
@@ -49,7 +49,6 @@ class TestPendoParentStreams(unittest.TestCase):
     def test_get_body(self, stream_class, exp_event_type, exp_event_type_value, exp_filter_key, kwargs):
         """Verify get_body method returns an expected request body object"""
         stream_obj = stream_class(default_config)
-        # body = stream_obj.get_body()
         body = stream_obj.get_body(**kwargs) if kwargs else stream_obj.get_body()
         sort_index = stream_obj.get_pipeline_key_index(body, "sort")
         filter_index = stream_obj.get_pipeline_key_index(body, "filter")


### PR DESCRIPTION
# Description of change
Connection failures observed with OOM issues or request timeouts for non-event based streams. Primary reason for that is we are trying to pull all data at once which sometimes causes OOM or request timeouts.

We had fixed similar issue for event based streams in the past so extended and generalised similar fix to all applicable streams.

- Added filter, sorting and limit parameters to applicable incremental streams 
- Moved common methods to parent classes
- Changed inheritance for `events` and `poll_events` streams
- Write unittests

# Manual QA steps
 - Ran integration tests on local dev env and verified the fix
 - Ran unittests
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
