### PR TITLE
bump version 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.5.2
+  * Fixes visitor_history duplicate record sync issue [#119](https://github.com/singer-io/tap-pendo/pull/119)
+
 ## 0.5.1
   * Skips visitor_history records for visitors with Do Not Process flag [#115](https://github.com/singer-io/tap-pendo/pull/115)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-pendo",
-    version="0.5.1",
+    version="0.5.2",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="https://github.com/singer-io/tap-pendo",


### PR DESCRIPTION
# Description of change
- Fixes visitor_history duplicate record sync issue [#119](https://github.com/singer-io/tap-pendo/pull/119)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
