### PR TITLE
TDL-22606 fix none replication_value records sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.6.1
+  * Fix the type error in the accounts stream records that resulted from comparing a none value. [#122](https://github.com/singer-io/tap-pendo/pull/122)
+
 ## 0.6.0
   * Fix connection reset, request timeout and memory overflow issues [#116](https://github.com/singer-io/tap-pendo/pull/116)
   * Refactor child stream methods

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-pendo",
-    version="0.6.0",
+    version="0.6.1",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="https://github.com/singer-io/tap-pendo",

--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -149,6 +149,7 @@ class Stream():
     def __init__(self, config=None):
         self.config = config
         self.record_limit = self.get_default_record_limit()
+        self.none_replication_value_records = []
 
         # If value is 0,"0", "" or None then it will set default to default to 300.0 seconds if not passed in config.
         config_request_timeout = self.config.get('request_timeout')
@@ -549,20 +550,43 @@ class Stream():
 
         return body
 
+    def get_replication_value(self, record):
+        """Return the replication value of """
+        if isinstance(self, Accounts):
+            return record['metadata']['auto']['lastupdated']
+
+        decamalized_replication_key = humps.decamelize(self.replication_key)
+        return record.get(decamalized_replication_key)
+
+    def remove_none_replication_value_records(self, records):
+        """Removes the none replication_value records to avoid duplicates records"""
+        if len(records) > 0:
+            for i in range(len(records)-1, -1, -1):
+                if self.get_replication_value(records[i]):
+                    continue
+
+                last_record = records.pop(i)
+                if last_record not in self.none_replication_value_records:
+                    # add removed records to be synced at the end
+                    self.none_replication_value_records.append(last_record)
+
+        return records
+
     def remove_last_timestamp_records(self, records):
         """Removes the overlapping records with last timestamp value. This avoids possibilty of duplicates"""
         last_processed = []
-        decamalized_replication_key = humps.decamelize(self.replication_key)
 
         if len(records) > 0:
-            if isinstance(self, Accounts):
-                timestamp = records[-1]['metadata']['auto']['lastupdated']
-                while records and timestamp == records[-1]['metadata']['auto']['lastupdated']:
-                    last_processed.append(records.pop())
-            else:
-                timestamp = records[-1].get(decamalized_replication_key)
-                while records and timestamp == records[-1].get(decamalized_replication_key):
-                    last_processed.append(records.pop())
+            if records and self.last_processed:
+                # Previously removed records get duplicated in subsequent api response which needs to be removed
+                records = [record for record in records if self.get_replication_value(
+                    record) >= self.get_replication_value(self.last_processed[0])]
+
+            if records:
+                timestamp = self.get_replication_value(records[-1])
+                while records and timestamp == self.get_replication_value(records[-1]):
+                    last = records.pop()
+                    last_processed.append(last)
 
         # This is a corner cases where all records in the set have same timestamp
         # This can occur if record limit is set very smaller compared to the max record limit
@@ -571,7 +595,7 @@ class Stream():
         if len(records) == 0 or not last_processed:
             self.record_limit = API_RECORD_LIMIT
 
-        return last_processed
+        return records, last_processed
 
     def get_first_parameter_value(self, body):
         return body['request']['pipeline'][0]['source']['timeSeries'].get('first', 0)
@@ -600,7 +624,7 @@ class Stream():
 
         # If last processed records exists, then set first to timestamp of first record
         if self.last_processed:
-            first = self.last_processed[0][humps.decamelize(self.replication_key)]
+            first = self.get_replication_value(self.last_processed[0])
         else:
             first = int(start_date.timestamp()) * 1000
 
@@ -614,21 +638,13 @@ class Stream():
             # Loop breaks when paged response returns lesser records than set record limit
             records = self.request(self.name, json=body).get('results') or []
 
-            # Set first and filters for next request
-            self.set_request_body_filters(
-                body,
-                first,
-                records)
-
             if len(records) > 1:
-                # Previously removed records get duplicated in subsequent api response which needs to be removed
-                if self.last_processed:
-                    decamelized_replication_key = humps.decamelize(self.replication_key)
-                    records = [record for record in records if record.get(
-                        decamelized_replication_key) >= self.last_processed[0].get(decamelized_replication_key)]
-
-                removed_records = self.remove_last_timestamp_records(records)
+                self.remove_none_replication_value_records(records)
+                records, removed_records = self.remove_last_timestamp_records(records)
                 stream_records += records
+
+                # Set first and filters for next request
+                self.set_request_body_filters(body, first, records)
 
                 if self.last_processed == removed_records:
                     stream_records += removed_records
@@ -650,6 +666,12 @@ class Stream():
 
         # These is a corner cases where this limit may get changed so reseeting it before next iteration
         self.record_limit = self.get_default_record_limit()
+
+        if not loop_for_records:
+            # Add none replication_value records with records with valid replication_value
+            # before syncing the sud-stream records
+            stream_records.extend(self.none_replication_value_records)
+            self.none_replication_value_records = []
 
         # Sync substream if the current stream has sub-stream and selected in the catalog
         if stream_records and sub_stream and sub_stream.is_selected():
@@ -807,7 +829,9 @@ class EventsBase(Stream):
                     self.last_processed = None
                     break
 
-                removed_records = self.remove_last_timestamp_records(records)
+                # Remove last processed and none replication_value records
+                self.remove_none_replication_value_records(records)
+                records, removed_records = self.remove_last_timestamp_records(records)
                 if len(records) > 0:
                     events += records
 

--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -561,16 +561,14 @@ class Stream():
     def remove_none_replication_value_records(self, records):
         """Removes the none replication_value records to avoid duplicates records"""
         if len(records) > 0:
-            for i in range(len(records)-1, -1, -1):
-                if self.get_replication_value(records[i]):
+            for index in range(len(records)-1, -1, -1):
+                if self.get_replication_value(records[index]):
                     continue
 
-                last_record = records.pop(i)
+                last_record = records.pop(index)
                 if last_record not in self.none_replication_value_records:
                     # add removed records to be synced at the end
                     self.none_replication_value_records.append(last_record)
-
-        return records
 
     def remove_last_timestamp_records(self, records):
         """Removes the overlapping records with last timestamp value. This avoids possibilty of duplicates"""
@@ -668,7 +666,7 @@ class Stream():
         self.record_limit = self.get_default_record_limit()
 
         if not loop_for_records:
-            # Add none replication_value records with records with valid replication_value
+            # Add none replication_value records into records with valid replication_value
             # before syncing the sud-stream records
             stream_records.extend(self.none_replication_value_records)
             self.none_replication_value_records = []
@@ -867,6 +865,10 @@ class EventsBase(Stream):
 
         # These is a corner cases where this limit may get changed so reseeting it before next iteration
         self.record_limit = self.get_default_record_limit()
+
+        # Add none replication_value records into records with valid replication_value
+        events.extend(self.none_replication_value_records)
+        self.none_replication_value_records = []
 
         update_currently_syncing(state, None)
         return (self.stream, events), False

--- a/tests/unittests/test_parent_stream_sync.py
+++ b/tests/unittests/test_parent_stream_sync.py
@@ -156,7 +156,7 @@ class TestPendoParentStreams(unittest.TestCase):
         (Events,),
         (PollEvents,),
         (GuideEvents,)])
-    def test_remove_none_replication_value_records(self, stream_class):
+    def test_remove_empty_replication_key_records(self, stream_class):
         """Verify response records with none replication value are removed
         and are stored in another list as expected"""
         stream_obj = stream_class(default_config)
@@ -164,12 +164,12 @@ class TestPendoParentStreams(unittest.TestCase):
 
         # Verify if none replication value records are removed from mix records
         test_records = self.generate_null_records(stream_obj, 10)
-        stream_obj.remove_none_replication_value_records(test_records)
+        stream_obj.remove_empty_replication_key_records(test_records)
         self.assertEqual(len(test_records), 10)
-        self.assertEqual(len(stream_obj.none_replication_value_records), 3)
+        self.assertEqual(len(stream_obj.empty_replication_key_records), 3)
 
         # Verify if none replication value records are removed from records having only none replication value
         test_records = self.generate_null_records(stream_obj, 0)
-        stream_obj.remove_none_replication_value_records(test_records)
+        stream_obj.remove_empty_replication_key_records(test_records)
         self.assertEqual(len(test_records), 0)
-        self.assertEqual(len(stream_obj.none_replication_value_records), 3)
+        self.assertEqual(len(stream_obj.empty_replication_key_records), 3)

--- a/tests/unittests/test_parent_stream_sync.py
+++ b/tests/unittests/test_parent_stream_sync.py
@@ -35,6 +35,24 @@ class TestPendoParentStreams(unittest.TestCase):
 
         return test_records
 
+    def generate_null_records(self, stream_obj, num_records, num_none_replication_value=3):
+        test_records = []
+        offset = 1000000
+        replication_key = humps.decamelize(stream_obj.replication_key)
+
+        if isinstance(stream_obj, Accounts):
+            test_records = [{"appID": 10000, "metadata": {"auto": {"lastupdated": offset+i}}} for i in range(num_records)]
+            test_records.insert(0, {"appID": 10001, "metadata": {"auto": {"lastupdated": None}}})
+            test_records.insert(-1, {"appID": 10002, "metadata": {"auto": {"lastupdated": None}}})
+            test_records.insert(int(len(test_records)/2), {"appID": 10003, "metadata": {"auto": {"lastupdated": None}}})
+        else:
+            test_records = [{"appID": 10001, replication_key: offset+i} for i in range(num_records)]
+            test_records.insert(0, {"id": 10002, replication_key: None})
+            test_records.insert(-1, {"id": 10003, replication_key: None})
+            test_records.insert(int(len(test_records)/2), {"id": 10000, replication_key: None})
+
+        return test_records
+
     @parameterized.expand(
         [(Accounts, "accounts", None, "metadata.auto.lastupdated", None),
         (Features, "features", None, "lastUpdatedAt", None),
@@ -111,15 +129,47 @@ class TestPendoParentStreams(unittest.TestCase):
 
         # Verify if records have distinct replication key value then only one record is removed
         test_records = self.generate_records(stream_obj, 10)
-        self.assertEqual(len(stream_obj.remove_last_timestamp_records(test_records)), 1)
+        records, removed_records = stream_obj.remove_last_timestamp_records(test_records)
+        self.assertEqual(len(records), 9)
+        self.assertEqual(len(removed_records), 1)
         self.assertEqual(stream_obj.record_limit, record_limit)
 
         # Verify if records have 'nn distinct replication key value then 'n' record is removed
         test_records = self.generate_records(stream_obj, 10, 5)
-        self.assertEqual(len(stream_obj.remove_last_timestamp_records(test_records)), 5)
+        records, removed_records = stream_obj.remove_last_timestamp_records(test_records)
+        self.assertEqual(len(records), 10)
+        self.assertEqual(len(removed_records), 5)
         self.assertEqual(stream_obj.record_limit, record_limit)
 
         # Verify if all records have equal replication key value then record limit is set to default
         test_records = self.generate_records(stream_obj, 0, record_limit)
-        self.assertEqual(len(stream_obj.remove_last_timestamp_records(test_records)), record_limit)
+        records, removed_records = stream_obj.remove_last_timestamp_records(test_records)
+        self.assertEqual(len(records), 0)
+        self.assertEqual(len(removed_records), record_limit)
         self.assertEqual(stream_obj.record_limit, API_RECORD_LIMIT)
+
+
+    @parameterized.expand(
+        [(Accounts,),
+        (Features,),
+        (TrackTypes,),
+        (Events,),
+        (PollEvents,),
+        (GuideEvents,)])
+    def test_remove_none_replication_value_records(self, stream_class):
+        """Verify response records with none replication value are removed
+        and are stored in another list as expected"""
+        stream_obj = stream_class(default_config)
+        record_limit = stream_obj.record_limit  # original record limit value
+
+        # Verify if none replication value records are removed from mix records
+        test_records = self.generate_null_records(stream_obj, 10)
+        stream_obj.remove_none_replication_value_records(test_records)
+        self.assertEqual(len(test_records), 10)
+        self.assertEqual(len(stream_obj.none_replication_value_records), 3)
+
+        # Verify if none replication value records are removed from records having only none replication value
+        test_records = self.generate_null_records(stream_obj, 0)
+        stream_obj.remove_none_replication_value_records(test_records)
+        self.assertEqual(len(test_records), 0)
+        self.assertEqual(len(stream_obj.none_replication_value_records), 3)


### PR DESCRIPTION
# Description of change
Fix TypeError observed while syncing accounts records (TDL-22606)

There were two scenarios which could cause TypeError which we fixed,
- None replication_value records in parent streams
- [L#628](https://github.com/singer-io/tap-pendo/blob/master/tap_pendo/streams.py#L628) returns none  for Account streams because we are trying to access non-existent key in a record.

Also, refactored code to avoid duplication code and have generic implementation.


# Manual QA steps
 - Simulated none replication value records and tested implementation on local dev env.
 - Verified Account stream sync doesn't break if there are more records than `record_limit` value.
 - Verified unittests and integration tests pass on local env.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
