### PR TITLE
set max record limit when run into  race condition

### DIFF
--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -591,7 +591,7 @@ class Stream():
         # In this case we will try to set record limit to max limit to make it harder to run into this issue
         # But still can't completely dismiss the minor possibility of this issue occurring
         if len(records) == 0 or not last_processed:
-            self.record_limit = API_RECORD_LIMIT
+            self.record_limit = max(self.record_limit, API_RECORD_LIMIT)
 
         return records, last_processed
 

--- a/tests/unittests/test_record_limit.py
+++ b/tests/unittests/test_record_limit.py
@@ -70,3 +70,23 @@ class TestRecordLimit(unittest.TestCase):
         mock_remove_last_records.return_value = test_data[0]["results"], []
         _, actual_loop_for_records = event_obj.sync(mock_state, mock_start_date, "PARENT-ID")
         self.assertEqual(actual_loop_for_records, expected_loop_for_records)
+
+
+    @parameterized.expand(
+        [("lesser_than_record_limit", API_RECORD_LIMIT-1, API_RECORD_LIMIT),
+         ("equal_to_record_limit", API_RECORD_LIMIT, API_RECORD_LIMIT),
+         ("greater_than_record_limit", API_RECORD_LIMIT+1, API_RECORD_LIMIT+1)])
+    def test_remove_last_timestamp_records(self, name, record_limit, expected_record_limit):
+        # create records with same replication value
+        number_of_records = 100
+        source_records = [{event_obj.replication_key: 100}] * number_of_records
+
+        event_obj = EventsBase({"record_limit": record_limit})
+        event_obj.replication_key = "hour"
+        event_obj.record_limit = record_limit
+
+        records, last_processed = event_obj.remove_last_timestamp_records(records=source_records)
+        self.assertEquals(len(records), 0)
+        self.assertEquals(len(last_processed), number_of_records)
+        self.assertEquals(event_obj.record_limit, expected_record_limit)
+

--- a/tests/unittests/test_record_limit.py
+++ b/tests/unittests/test_record_limit.py
@@ -79,11 +79,10 @@ class TestRecordLimit(unittest.TestCase):
     def test_remove_last_timestamp_records(self, name, record_limit, expected_record_limit):
         # create records with same replication value
         number_of_records = 100
-        source_records = [{event_obj.replication_key: 100}] * number_of_records
-
         event_obj = EventsBase({"record_limit": record_limit})
         event_obj.replication_key = "hour"
         event_obj.record_limit = record_limit
+        source_records = [{event_obj.replication_key: 100}] * number_of_records
 
         records, last_processed = event_obj.remove_last_timestamp_records(records=source_records)
         self.assertEquals(len(records), 0)


### PR DESCRIPTION
# Description of change
This PR fixes the issue discussed below,

We have set default `record_limit=100000` to reduce memory pressure. But theoretically if we have enough memory we can set `record_limit` higher. As per current implementation, if we run into race condition then it may get reset to default limit which is lesser than configured limit.

# Manual QA steps
 - added new unittest and verified the fix on dev env
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
