### PR TITLE
Use replication_key in last_processed instead of primary_key

### DIFF
--- a/tap_pendo/streams.py
+++ b/tap_pendo/streams.py
@@ -405,7 +405,7 @@ class Stream():
                         # Skipping last synced parent ids
                         continue
                 except TypeError:
-                    # If last_processed_key(str primary key previously, int replication_key now) is not comparable, 
+                    # If last_processed_key(str primary key previously, int replication_key now) is not comparable,
                     # set last_processed to current record's replication key value
                     LOGGER.warning("Found non-comparable value for last_processed_key: %s", last_processed_key)
                     last_processed = record.get(last_processed_key)


### PR DESCRIPTION
# Description of change
```
for record in parent_response:
      try:
          if last_processed and record.get(parent.key_properties[0]) < last_processed:
              # Skipping last synced parent ids
              continue
```

- Here, sync_substream looks for the last processed parent_id to decide the parent to process.  But, LT operator does not correctly compare the alpha numeric id’s since the sorting on the parent stream is based on the replication key i.e updated at. So on interrupted sync, it would miss some records which has id value less than the already synced id.
- So, we are updating last_processed value with replication_key value instead of primary key i.e id

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
