### PR TITLE
SAC-28870-add-new-metadata changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3.1
+  * The change enables sub-streams to reference their parent streams through metadata [#137](https://github.com/singer-io/tap-pendo/pull/137)
+
 ## 1.2.1
   * Unpin pyhump dependency and refactor for pylint errors [#136](https://github.com/singer-io/tap-pendo/pull/136)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-pendo",
-    version="1.2.1",
+    version="1.3.1",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="https://github.com/singer-io/tap-pendo",

--- a/tap_pendo/discover.py
+++ b/tap_pendo/discover.py
@@ -145,11 +145,13 @@ def discover_streams(config):
             for name, child in SUB_STREAMS.items():
                 if child == stream_name:
                     parent = name
+        if parent:
+            mdata[()]['parent-tap-stream-id'] = parent
+
         stream = {
             'stream': s.name,
             'tap_stream_id': s.name,
             'schema': schema,
-            **({'parent-stream-id': parent} if parent else {}),
             'metadata': metadata.to_list(mdata)
         }
 

--- a/tap_pendo/discover.py
+++ b/tap_pendo/discover.py
@@ -3,7 +3,7 @@ import os
 import singer
 from singer import metadata
 
-from tap_pendo.streams import STREAMS
+from tap_pendo.streams import STREAMS, SUB_STREAMS
 
 LOGGER = singer.get_logger()
 
@@ -139,10 +139,17 @@ def discover_streams(config):
         if s.name == 'metadata_visitors':
             build_metadata_metadata(mdata, schema, custom_visitor_fields)
 
+        stream_name = s.name
+        parent = None
+        if stream_name in SUB_STREAMS.values():
+            for name, child in SUB_STREAMS.items():
+                if child == stream_name:
+                    parent = name
         stream = {
             'stream': s.name,
             'tap_stream_id': s.name,
             'schema': schema,
+            **({'parent-stream-id': parent} if parent else {}),
             'metadata': metadata.to_list(mdata)
         }
 

--- a/tests/tap_tester/base.py
+++ b/tests/tap_tester/base.py
@@ -22,6 +22,7 @@ class TestPendoBase(unittest.TestCase):
     INCREMENTAL = "INCREMENTAL"
     FULL_TABLE = "FULL_TABLE"
     START_DATE_FORMAT = "%Y-%m-%dT00:00:00Z"
+    PARENT_TAP_STREAM_ID = "parent-tap-stream-id"
     BOOKMARK_COMPARISON_FORMAT = "%Y-%m-%dT%H:%M%S%z"
     start_date = ""
     is_day_range = True
@@ -74,7 +75,8 @@ class TestPendoBase(unittest.TestCase):
             "visitor_history": {
                 self.PRIMARY_KEYS: {'visitor_id'},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.REPLICATION_KEYS: {'modified_ts'}
+                self.REPLICATION_KEYS: {'modified_ts'},
+                self.PARENT_TAP_STREAM_ID: 'visitors'
             },
             "visitors": {
                 self.PRIMARY_KEYS: {'visitor_id'},
@@ -89,7 +91,8 @@ class TestPendoBase(unittest.TestCase):
             "feature_events":{
                 self.PRIMARY_KEYS: {"feature_id", "visitor_id", "account_id", "remote_ip", "user_agent", event_replication_key},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.REPLICATION_KEYS: {event_replication_key}
+                self.REPLICATION_KEYS: {event_replication_key},
+                self.PARENT_TAP_STREAM_ID: 'features'
             },
             "events": {
                 self.PRIMARY_KEYS: {"visitor_id", "account_id", "remote_ip", "user_agent", event_replication_key},
@@ -99,12 +102,14 @@ class TestPendoBase(unittest.TestCase):
             "page_events": {
                 self.PRIMARY_KEYS: {"page_id", "visitor_id", "account_id", "remote_ip", "user_agent", event_replication_key},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.REPLICATION_KEYS: {event_replication_key}
+                self.REPLICATION_KEYS: {event_replication_key},
+                self.PARENT_TAP_STREAM_ID: 'pages'
             },
             "guide_events": {
                 self.PRIMARY_KEYS: {"guide_id", "guide_step_id", "visitor_id", "type", "account_id", "browser_time", "url"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.REPLICATION_KEYS: {'browser_time'}
+                self.REPLICATION_KEYS: {'browser_time'},
+                self.PARENT_TAP_STREAM_ID: 'guides'
             },
             "poll_events":{
                 self.PRIMARY_KEYS: {"visitor_id", "account_id", "poll_id", "browser_time"},
@@ -114,7 +119,8 @@ class TestPendoBase(unittest.TestCase):
             "track_events": {
                 self.PRIMARY_KEYS: {"track_type_id", "visitor_id", "account_id", "remote_ip", "user_agent", event_replication_key},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.REPLICATION_KEYS: {event_replication_key}
+                self.REPLICATION_KEYS: {event_replication_key},
+                self.PARENT_TAP_STREAM_ID: 'track_types'
             },
             "metadata_accounts": {
                 self.REPLICATION_METHOD: self.FULL_TABLE,

--- a/tests/tap_tester/test_discovery.py
+++ b/tests/tap_tester/test_discovery.py
@@ -68,16 +68,29 @@ class PendoDiscoverTest(TestPendoBase):
                     stream_properties[0].get(
                         "metadata", {self.REPLICATION_KEYS: []}).get(self.REPLICATION_KEYS, [])
                 )
-                actual_replication_method = stream_properties[0].get(
-                    "metadata", {self.REPLICATION_METHOD: None}).get(self.REPLICATION_METHOD)
+                actual_replication_method = stream_properties[0].get("metadata", {self.REPLICATION_METHOD: None}).get(self.REPLICATION_METHOD)
                 actual_automatic_fields = set(
                     item.get("breadcrumb", ["properties", None])[1] for item in metadata
                     if item.get("metadata").get("inclusion") == "automatic"
                 )
-                
+                expected_parent = self.expected_metadata()[stream].get(self.PARENT_TAP_STREAM_ID)
+                actual_parent = stream_properties[0].get("metadata", {}).get(self.PARENT_TAP_STREAM_ID)
+
                 ##########################################################################
                 # metadata assertions
                 ##########################################################################
+
+                if expected_parent:
+                    self.assertEqual(
+                        expected_parent,
+                        actual_parent,
+                        msg=f"Expected parent-tap-stream-id '{expected_parent}' but got '{actual_parent}' for stream {stream}"
+                    )
+                else:
+                    self.assertIsNone(
+                        actual_parent,
+                        msg=f"Unexpected parent-tap-stream-id found for stream {stream}: {actual_parent}"
+                    )
 
                 # verify there is only 1 top level breadcrumb in metadata
                 self.assertTrue(len(stream_properties) == 1,


### PR DESCRIPTION
## Pull Request Overview

This PR adds metadata parent-stream relationship tracking to the stream discovery process in the Pendo tap connector. The change enables sub-streams to reference their parent streams through metadata.

[SAC-28870](https://qlik-dev.atlassian.net/browse/SAC-28870)

- Imports SUB_STREAMS configuration from streams module
- Adds logic to identify parent-child stream relationships
- Includes parent stream ID in stream metadata when applicable

